### PR TITLE
Add review submission page, display HeritageSite information on it

### DIFF
--- a/bcrhp/src/bcrhp/pages/NewSite.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite.vue
@@ -23,6 +23,7 @@ import UploadImage from './steps/Step7_UploadImage.vue';
 import SiteClassification from './steps/Step8_SiteClassification.vue';
 import SiteDetails from './steps/Step9_SiteDetails.vue';
 import SupportingDocuments from './steps/Step10_SupportingDocuments.vue';
+import ReviewSubmission from './steps/Step11_ReviewSubmission.vue';
 
 import { getHeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
 import { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
@@ -379,6 +380,7 @@ const showDebug = ref(false);
                             <div class="">
                                 <div class="step-title">Review Submission</div>
                             </div>
+                            <ReviewSubmission ref="step11"></ReviewSubmission>
                             <div class="">
                                 <StepperNavigation
                                     :step-number="6"

--- a/bcrhp/src/bcrhp/pages/steps/Step11_ReviewSubmission.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step11_ReviewSubmission.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import { inject } from 'vue';
+import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
+
+const heritageSite: typeof HeritageSite = inject(
+    'heritageSite',
+) as typeof HeritageSite;
+</script>
+<template>
+    <div
+        v-for="address in heritageSite.civicAddress"
+        :key="address"
+    >
+        <p class="mb-2 underline font-bold">Address</p>
+        <p>Street Address {{ address.streetAddress }}</p>
+        <p>Detailed Location {{ address.streetAddress }}</p>
+        <p>Legal Description {{ address.streetAddress }}</p>
+    </div>
+    <div>
+        <p class="mb-2 underline font-bold">Site Names</p>
+        <p>Common {{ heritageSite.commonName }}</p>
+        <div
+            v-for="name in heritageSite.otherNames"
+            :key="name"
+        >
+            <p>Alternate {{ name }}</p>
+        </div>
+    </div>
+    <div>
+        <p class="mb-2 underline font-bold">Official Recognition Details</p>
+        <p>Start Date {{ heritageSite.commonName }}</p>
+        <p>Legislative Act {{ heritageSite.commonName }}</p>
+        <div
+            v-for="number in heritageSite.referenceNumbers"
+            :key="number"
+        >
+            <p>Reference Number {{ number }}</p>
+        </div>
+    </div>
+    <div>
+        <p class="mb-2 underline font-bold">Statement of Significance</p>
+        <p>Description <span v-html="heritageSite.description"> </span></p>
+        <p>Heritage Value <span v-html="heritageSite.heritageValue"> </span></p>
+        <p>
+            Character Defining Elements
+            <span v-html="heritageSite.definingElements"> </span>
+        </p>
+        <p>Document Location {{ heritageSite.documentLocation }}</p>
+    </div>
+    <div>
+        <p class="mb-2 underline font-bold">Images</p>
+        <div
+            v-for="image in heritageSite.uploadImage"
+            :key="image"
+        >
+            <p>Type {{ image.imageType }}</p>
+            <p>View {{ image.imageView }}</p>
+            <p>Features {{ image.imageFeatures }}</p>
+            <p>Date {{ image.imageDate }}</p>
+            <p>Description {{ image.imageDescription }}</p>
+            <p>Photographer {{ image.photographer }}</p>
+            <p>Copyright {{ image.copyright }}</p>
+        </div>
+        <div>
+            <p class="mb-2 underline font-bold">Site Details</p>
+            <p>Heritage Class</p>
+            <div
+                v-for="contributingResource in heritageSite.totalContributingResources"
+                :key="contributingResource"
+            >
+                <p>{{ contributingResource }}</p>
+            </div>
+            <p>Heritage Function</p>
+            <div
+                v-for="heritageTheme in heritageSite.heritageThemes"
+                :key="heritageTheme"
+            >
+                <p>{{ heritageTheme }}</p>
+            </div>
+            <p>Heritage Theme</p>
+            <div
+                v-for="functionCategory in heritageSite.functionCategories"
+                :key="functionCategory"
+            >
+                <p>{{ functionCategory }}</p>
+            </div>
+        </div>
+        <div>
+            <p class="mb-2 underline font-bold">Site Classification</p>
+            <p>Chronology</p>
+            <div
+                v-for="chronology in heritageSite.chronologies"
+                :key="chronology"
+            >
+                <p>{{ chronology }}</p>
+            </div>
+            <p>Architects / Builders</p>
+            <div
+                v-for="architectOrBuilder in heritageSite.architectsOrBuilders"
+                :key="architectOrBuilder"
+            >
+                <p>{{ architectOrBuilder }}</p>
+            </div>
+            <p>URLs</p>
+            <div
+                v-for="url in heritageSite.urls"
+                :key="url"
+            >
+                <p>{{ url }}</p>
+            </div>
+        </div>
+        <div>
+            <p class="mb-2 underline font-bold">Supporting Documents</p>
+            {{ heritageSite.documentDescription }}
+            {{ heritageSite.submissionNotes }}
+        </div>
+    </div>
+</template>

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -6,7 +6,9 @@ import FieldSet from 'primevue/fieldset';
 import InputText from 'primevue/inputtext';
 import Checkbox from 'primevue/checkbox';
 import Button from 'primevue/button';
+import DatePicker from 'primevue/datepicker';
 
+import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePlaceholder/MultiValuePlaceholder.vue';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import LabelledCheckboxInput from '@/bcgov_arches_common/components/labelledinput/LabelledCheckbox.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
@@ -21,7 +23,9 @@ const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
 
-let otherName = '';
+const referenceNumber = ref('');
+const referenceNumbers = ref([] as Array<string>);
+const addOtherReferenceNumberDisabled = ref(false);
 
 // These names need to match the Zog schema
 const fields = {
@@ -42,6 +46,12 @@ const isValid = () => {
         valid = validateField(field?.value.$el as HTMLInputElement) && valid;
     }
     return valid;
+};
+
+const updateAddOtherRefNumber = function () {
+    addOtherReferenceNumberDisabled.value =
+        referenceNumber.value.length < 1 ||
+        heritageSiteRef.value.referenceNumbers.length > 4;
 };
 
 const valueUpdated = function (value: string | undefined) {
@@ -68,6 +78,7 @@ const validateField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
     const key: keyof typeof HeritageSite =
         field.id as keyof typeof HeritageSite;
+    console.log(key);
     const fieldValidation = requiredHeritageSiteSchema.shape[key].safeParse(
         heritageSiteRef.value[key],
     );
@@ -85,8 +96,14 @@ const validateField = function (field: HTMLInputElement) {
 
 const saveReferenceNumber = function () {
     console.log('saveReferenceNumber');
-    heritageSite.otherNames.push(otherName);
-    otherName = '';
+    heritageSiteRef.value.referenceNumbers.push(referenceNumber.value);
+    referenceNumber.value = '';
+    updateAddOtherRefNumber();
+};
+
+const deleteReferenceNumberCallback = function (index: number) {
+    heritageSiteRef.value.referenceNumbers.splice(index, 1);
+    updateAddOtherRefNumber();
 };
 
 let validateFields = false;
@@ -95,7 +112,10 @@ let validateFields = false;
 // configuration so API methods are not
 defineExpose({ isValid });
 
-onMounted(() => {});
+onMounted(() => {
+    heritageSiteRef.value.referenceNumbers = referenceNumbers;
+    updateAddOtherRefNumber();
+});
 </script>
 <template>
     <FieldSet id="recognitionDetailsFieldset">
@@ -107,18 +127,12 @@ onMounted(() => {});
             :required="true"
         >
             <div class="p-inputtext-fluid">
-                <InputText
+                <DatePicker
                     id="designationDate"
                     ref="designationDateField"
                     v-model="heritageSite.designationDate"
                     aria-describedby="designation-date-help"
                     aria-required="true"
-                    fluid
-                    class="inline-block"
-                    @change="valueChanged"
-                    @focus="onFocusHandler"
-                    @focusout="onFocusOutHandler"
-                    @update:model-value="valueUpdated"
                 />
             </div>
         </LabelledInput>
@@ -129,7 +143,7 @@ onMounted(() => {});
             :error-message="errors.legislativeAct?.join(',')"
             :required="true"
         >
-            <div class="p-inputtext-fluid">
+            <div class="p-inputtext-fluid flex">
                 <InputText
                     id="legislativeAct"
                     ref="legislativeActField"
@@ -170,14 +184,14 @@ onMounted(() => {});
             label="Reference Number"
             hint="The bylaw or resolution number"
             input-name="referenceNumber"
-            :error-message="errors.referenceNumber?.join(',')"
+            :error-message="errors.referenceNumbers?.join(',')"
             :required="true"
         >
             <div>
                 <InputText
                     id="referenceNumber"
                     ref="referenceNumberField"
-                    v-model="heritageSite.referenceNumber"
+                    v-model="referenceNumber"
                     aria-describedby="reference-number-help"
                     aria-required="true"
                     fluid
@@ -191,10 +205,20 @@ onMounted(() => {});
                     id="saveReferenceNumber"
                     label="Add"
                     class="inline-block"
+                    :aria-disabled="addOtherReferenceNumberDisabled"
                     @click="saveReferenceNumber"
                 ></Button>
             </div>
         </LabelledInput>
+        <MultiValuePlaceholder
+            v-slot="slotProps"
+            label="Reference Number"
+            :showDeleteButton="true"
+            :displayValues="referenceNumbers"
+            :deleteCallback="deleteReferenceNumberCallback"
+        >
+            <div class="parent value">{{ slotProps.value }}</div>
+        </MultiValuePlaceholder>
     </FieldSet>
 </template>
 

--- a/bcrhp/src/bcrhp/pages/steps/Step7_UploadImage.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_UploadImage.vue
@@ -4,6 +4,8 @@ import type { Ref } from 'vue';
 
 import InputText from 'primevue/inputtext';
 import Editor from 'primevue/editor';
+import DatePicker from 'primevue/datepicker';
+
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import type { UploadImage } from '@/bcrhp/schema/UploadImageSchema.ts';
 import { getUploadImage } from '@/bcrhp/schema/UploadImageSchema.ts';
@@ -177,21 +179,13 @@ onMounted(() => {});
         :error-message="errors.imageDate?.join(',')"
         :required="true"
     >
-        <div>
-            <InputText
-                id="imageDate"
-                ref="imageDateField"
-                v-model="uploadImage.imageDate"
-                aria-describedby="image-date-help"
-                aria-required="true"
-                fluid
-                class="inline-block"
-                @change="valueChanged"
-                @focus="onFocusHandler"
-                @focusout="onFocusOutHandler"
-                @update:model-value="valueUpdated"
-            />
-        </div>
+        <DatePicker
+            id="imageDate"
+            ref="imageDateField"
+            v-model="uploadImage.imageDate"
+            aria-describedby="image-date-help"
+            aria-required="true"
+        />
     </LabelledInput>
     <LabelledInput
         label="Image Description"

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -3,10 +3,11 @@ import { useTemplateRef, inject, ref, onMounted } from 'vue';
 import type { Ref } from 'vue';
 
 import FieldSet from 'primevue/fieldset';
-import InputText from 'primevue/inputtext';
 import Button from 'primevue/button';
 import Checkbox from 'primevue/checkbox';
+import Dropdown from 'primevue/dropdown';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
+import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePlaceholder/MultiValuePlaceholder.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
 import { requiredHeritageSiteSchema } from '@/bcrhp/schema/HeritageSiteSchema.ts';
 import type { ZodError } from 'zod';
@@ -18,7 +19,30 @@ const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
-let otherName = '';
+const contributingResourcesOptions = ref([
+    { name: '1', code: 1 },
+    { name: '2', code: 2 },
+    { name: '3', code: 3 },
+    { name: '4', code: 4 },
+    { name: '5', code: 5 },
+]);
+const functionCategoryOptions = ref([
+    { name: 'Market', code: 'market' },
+    { name: 'Eating or Drinking Establishment', code: 'eating_or_drinking' },
+]);
+const functionThemeOptions = ref([
+    { name: 'Learning and the Arts', code: 'learning_and_arts' },
+    { name: 'Architecture and Design', code: 'architecture_and_design' },
+]);
+const contributingResources = ref({ name: '', code: 0 });
+const totalContributingResources = ref([] as Array<string>);
+const functionCategory = ref({ name: '', code: '' });
+const functionCategories = ref([] as Array<string>);
+const heritageTheme = ref({ name: '', code: '' });
+const heritageThemes = ref([] as Array<string>);
+const addContributingResourcesDisabled = ref(false);
+const addOtherFunctionCategoryDisabled = ref(false);
+const addOtherHeritageSiteDisabled = ref(false);
 // const otherNames = ref(string[]);
 
 // These names need to match the Zog schema
@@ -45,24 +69,28 @@ const isValid = () => {
     return valid;
 };
 
+const updateAddContributingResourceCategory = function () {
+    addContributingResourcesDisabled.value =
+        contributingResources.value.code < 1 ||
+        heritageSiteRef.value.totalContributingResources.length > 4;
+};
+
+const updateAddOtherFunctionCategory = function () {
+    addOtherFunctionCategoryDisabled.value =
+        functionCategory.value.name !== '' ||
+        heritageSiteRef.value.functionCategories.length > 4;
+};
+
+const updateAddOtherHeritageSite = function () {
+    addOtherHeritageSiteDisabled.value =
+        heritageSiteRef.value.heritageThemes.length > 4;
+};
+
 const valueUpdated = function (value: string | undefined) {
+    console.log(contributingResources.value.code);
+    console.log(functionCategory.value.code);
+
     console.log(`valueUpdated: ${value}`);
-};
-
-const valueChanged = function (event: Event) {
-    console.log(`valueChanged`);
-    validateField(event.target as HTMLInputElement);
-};
-
-const onFocusHandler = function (event: Event) {
-    console.log(`onFocusHandler ${event}`);
-    // (event.target as HTMLInputElement).classList.remove("p-invalid");
-};
-
-const onFocusOutHandler = function (event: Event) {
-    console.log(`onFocusOutHandler`);
-    validateField(event.target as HTMLInputElement);
-    // (event.target as HTMLInputElement).classList.remove("p-invalid");
 };
 
 const validateField = function (field: HTMLInputElement) {
@@ -84,16 +112,45 @@ const validateField = function (field: HTMLInputElement) {
     return fieldValidation.success;
 };
 
-const addContributingSource = function () {
-    console.log('addContributingSource');
-    heritageSite.otherNames.push(otherName);
-    otherName = '';
+const saveContributingResource = function () {
+    console.log('saveContributingResource');
+    heritageSiteRef.value.totalContributingResources.push(
+        contributingResources.value,
+    );
+
+    updateAddContributingResourceCategory();
 };
 
 const saveFunctionCategory = function () {
     console.log('saveFunctionCategory');
-    heritageSite.otherNames.push(otherName);
-    otherName = '';
+    heritageSiteRef.value.functionCategories.push(functionCategory.value);
+
+    updateAddOtherFunctionCategory();
+};
+
+const saveHeritageTheme = function () {
+    console.log('saveHeritageThemes');
+    heritageSiteRef.value.heritageThemes.push(heritageTheme.value);
+
+    updateAddOtherHeritageSite();
+};
+
+const deleteContributingResourcesCallback = function (index: number) {
+    heritageSiteRef.value.totalContributingResources.splice(index, 1);
+
+    updateAddContributingResourceCategory();
+};
+
+const deleteFunctionCategoryCallback = function (index: number) {
+    heritageSiteRef.value.functionCategories.splice(index, 1);
+
+    updateAddOtherFunctionCategory();
+};
+
+const deleteHeritageThemeCallback = function (index: number) {
+    heritageSiteRef.value.heritageThemes.splice(index, 1);
+
+    updateAddOtherHeritageSite();
 };
 
 let validateFields = false;
@@ -102,7 +159,16 @@ let validateFields = false;
 // configuration so API methods are not
 defineExpose({ isValid });
 
-onMounted(() => {});
+onMounted(() => {
+    heritageSiteRef.value.totalContributingResources =
+        totalContributingResources;
+    heritageSiteRef.value.functionCategories = functionCategories;
+    heritageSiteRef.value.heritageThemes = heritageThemes;
+
+    updateAddContributingResourceCategory();
+    updateAddOtherFunctionCategory();
+    updateAddOtherHeritageSite();
+});
 </script>
 <template>
     <FieldSet
@@ -111,29 +177,31 @@ onMounted(() => {});
     >
         <LabelledInput
             label="Number of Contributing Resources"
-            input-name="referenceNumber"
-            :error-message="errors.referenceNumber?.join(',')"
+            input-name="contributingResources"
+            :error-message="errors.contributingResources?.join(',')"
             :required="true"
         >
             <div>
-                <InputText
-                    id="numberOfResources"
+                <Dropdown
+                    id="contributingResources"
                     ref="numberOfResourcesField"
-                    v-model="heritageSite.numberOfResources"
+                    v-model="contributingResources"
+                    placeholder="0"
+                    optionLabel="name"
+                    :options="contributingResourcesOptions"
                     aria-describedby="reference-number-help"
                     aria-required="true"
                     fluid
-                    class="inline-block"
-                    @change="valueChanged"
-                    @focus="onFocusHandler"
-                    @focusout="onFocusOutHandler"
+                    class="w-full md:w-14rem"
                     @update:model-value="valueUpdated"
                 />
                 <Button
-                    id="saveReferenceNumber"
+                    id="saveContributingResources"
+                    :disabled="addContributingResourcesDisabled"
+                    :aria-disabled="addContributingResourcesDisabled"
                     label="Add"
                     class="inline-block"
-                    @click="addContributingSource"
+                    @click="saveContributingResource"
                 ></Button>
             </div>
         </LabelledInput>
@@ -239,6 +307,15 @@ onMounted(() => {});
                 </div>
             </div>
         </div>
+        <MultiValuePlaceholder
+            v-slot="slotProps"
+            :showDeleteButton="true"
+            :displayValues="totalContributingResources"
+            label="Contributing Resource(s)"
+            :deleteCallback="deleteContributingResourcesCallback"
+        >
+            <div class="parent value">{{ slotProps.value.name }}</div>
+        </MultiValuePlaceholder>
     </FieldSet>
     <Fieldset
         id="heritageFunctionFieldset"
@@ -248,21 +325,21 @@ onMounted(() => {});
         <LabelledInput
             label="Function Category"
             input-name="heritageTheme"
-            :error-message="errors.functionCategory?.join(',')"
+            :error-message="errors.functionCategories?.join(',')"
             :required="true"
         >
             <div class="p-inputtext-fluid flex flex-row">
-                <InputText
+                <Dropdown
                     id="functionCategory"
                     ref="functionCategoryField"
-                    v-model="heritageSite.functionCategory"
+                    v-model="functionCategory"
+                    optionLabel="name"
+                    placeholder="Select Function Category"
+                    :options="functionCategoryOptions"
                     aria-describedby="function-category-help"
                     aria-required="true"
                     fluid
-                    class="inline-block"
-                    @change="valueChanged"
-                    @focus="onFocusHandler"
-                    @focusout="onFocusOutHandler"
+                    class="w-full md:w-14rem"
                     @update:model-value="valueUpdated"
                 />
                 <div class="inline-block">
@@ -286,13 +363,24 @@ onMounted(() => {});
                     </div>
                 </div>
             </div>
+            <Button
+                id="addOtherName"
+                label="Add"
+                class="inline-block"
+                :disabled="addOtherFunctionCategoryDisabled"
+                :aria-disabled="addOtherFunctionCategoryDisabled"
+                @click="saveFunctionCategory"
+            ></Button>
         </LabelledInput>
-        <Button
-            id="addOtherName"
-            label="Add"
-            class="inline-block"
-            @click="saveFunctionCategory"
-        ></Button>
+        <MultiValuePlaceholder
+            v-slot="slotProps"
+            :showDeleteButton="true"
+            :displayValues="functionCategories"
+            label="Category/Categories"
+            :deleteCallback="deleteFunctionCategoryCallback"
+        >
+            <div class="parent value">{{ slotProps.value.name }}</div>
+        </MultiValuePlaceholder>
     </Fieldset>
     <Fieldset
         id="heritageThemeFieldset"
@@ -302,24 +390,42 @@ onMounted(() => {});
         <LabelledInput
             label="Heritage Theme"
             input-name="heritageTheme"
-            :error-message="errors.heritageTheme?.join(',')"
+            :error-message="errors.heritageThemes?.join(',')"
             :required="true"
         >
             <div class="p-inputtext-fluid">
-                <InputText
+                <Dropdown
                     id="heritageTheme"
                     ref="heritageThemeField"
-                    v-model="heritageSite.heritageTheme"
-                    aria-describedby="heritage-theme-help"
+                    v-model="heritageTheme"
+                    optionLabel="name"
+                    placeholder="Select Function Theme"
+                    :options="functionThemeOptions"
+                    aria-describedby="function-theme-help"
                     aria-required="true"
                     fluid
-                    @change="valueChanged"
-                    @focus="onFocusHandler"
-                    @focusout="onFocusOutHandler"
+                    class="w-full md:w-14rem"
                     @update:model-value="valueUpdated"
                 />
             </div>
+            <Button
+                id="addHeritageTheme"
+                label="Add"
+                class="inline-block"
+                :disabled="addOtherHeritageSiteDisabled"
+                :aria_disabled="addOtherHeritageSiteDisabled"
+                @click="saveHeritageTheme"
+            ></Button>
         </LabelledInput>
+        <MultiValuePlaceholder
+            v-slot="slotProps"
+            :showDeleteButton="true"
+            :displayValues="heritageThemes"
+            label="Theme(s)"
+            :deleteCallback="deleteHeritageThemeCallback"
+        >
+            <div class="parent value">{{ slotProps.value.name }}</div>
+        </MultiValuePlaceholder>
     </Fieldset>
 </template>
 

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -6,6 +6,9 @@ import FieldSet from 'primevue/fieldset';
 import InputText from 'primevue/inputtext';
 import Button from 'primevue/button';
 import Checkbox from 'primevue/checkbox';
+import DatePicker from 'primevue/datepicker';
+
+import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePlaceholder/MultiValuePlaceholder.vue';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
 import { requiredHeritageSiteSchema } from '@/bcrhp/schema/HeritageSiteSchema.ts';
@@ -15,11 +18,18 @@ const heritageSite: typeof HeritageSite = inject(
     'heritageSite',
 ) as typeof HeritageSite;
 const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
+const chronology = ref('');
+const chronologies = ref([] as Array<string>);
+const architectOrBuilder = ref('');
+const architectsOrBuilders = ref([] as Array<string>);
+const url = ref('');
+const urls = ref([] as Array<string>);
+const addURLDisabled = ref(false);
+const startYear = ref();
+const endYear = ref();
 
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
-let otherName = '';
-// const otherNames = ref(string[]);
 
 // These names need to match the Zog schema
 const eventType = ref();
@@ -28,7 +38,7 @@ const circa = ref();
 const fields = {
     startYearField: useTemplateRef('startYearField'),
     endYearField: useTemplateRef('endYearField'),
-    chronologyNotesField: useTemplateRef('chronologyNotesField'),
+    chronologyField: useTemplateRef('chronologyField'),
     architectOrBuilderNameField: useTemplateRef('architectOrBuilderNameField'),
     architectOrBuilderTypeField: useTemplateRef('architectOrBuilderTypeField'),
     urlTypeField: useTemplateRef('urlTypeField'),
@@ -89,21 +99,63 @@ const validateField = function (field: HTMLInputElement) {
     return fieldValidation.success;
 };
 
-const addChronologyNotes = function () {
-    console.log('saveOtherName');
-    heritageSite.otherNames.push(otherName);
-    otherName = '';
+const updateAddChronology = function () {
+    addURLDisabled.value =
+        chronology.value.length < 1 ||
+        heritageSiteRef.value.chronologies.length > 4;
+};
+const updateAddOtherArchitectOrBuilder = function () {
+    addURLDisabled.value =
+        architectOrBuilder.value.length < 1 ||
+        heritageSiteRef.value.architectsOrBuilders.length > 4;
 };
 
-const addArchitectOrBuilderNotes = function () {
-    console.log('saveOtherName');
-    heritageSite.otherNames.push(otherName);
-    otherName = '';
+const updateAddOtherURL = function () {
+    addURLDisabled.value =
+        url.value.length < 1 || heritageSiteRef.value.urls.length > 4;
 };
-const addURL = function () {
-    console.log('saveOtherName');
-    heritageSite.otherNames.push(otherName);
-    otherName = '';
+
+const saveChronology = function () {
+    console.log('saveChronology');
+    heritageSite.startYear = startYear.value;
+    heritageSite.endYear = endYear.value;
+    heritageSiteRef.value.chronologies.push(chronology.value);
+    architectOrBuilder.value = '';
+
+    updateAddChronology();
+};
+
+const saveArchitectOrBuilder = function () {
+    console.log('saveArchitectOrBuilder');
+    heritageSiteRef.value.architectsOrBuilders.push(architectOrBuilder.value);
+    architectOrBuilder.value = '';
+
+    updateAddOtherArchitectOrBuilder();
+};
+const saveURL = function () {
+    console.log('saveURL');
+    heritageSiteRef.value.urls.push(url.value);
+    url.value = '';
+
+    updateAddOtherURL();
+};
+
+const deleteChronologyCallback = function (index: number) {
+    heritageSiteRef.value.chronologies.splice(index, 1);
+
+    updateAddOtherArchitectOrBuilder();
+};
+
+const deleteArchitectBuilderCallback = function (index: number) {
+    heritageSiteRef.value.architectsOrBuilders.splice(index, 1);
+
+    updateAddOtherArchitectOrBuilder();
+};
+
+const deleteURLCallback = function (index: number) {
+    heritageSiteRef.value.urls.splice(index, 1);
+
+    updateAddOtherURL();
 };
 
 let validateFields = false;
@@ -112,7 +164,15 @@ let validateFields = false;
 // configuration so API methods are not
 defineExpose({ isValid });
 
-onMounted(() => {});
+onMounted(() => {
+    heritageSiteRef.value.chronologies = chronologies;
+    heritageSiteRef.value.architectsOrBuilders = architectsOrBuilders;
+    heritageSiteRef.value.urls = urls;
+
+    updateAddChronology();
+    updateAddOtherArchitectOrBuilder();
+    updateAddOtherURL();
+});
 </script>
 <template>
     <FieldSet
@@ -145,51 +205,24 @@ onMounted(() => {});
                     </div>
                 </div>
             </div>
-            <LabelledInput
-                label="Start Year"
-                input-name="startYear"
-                class="inline-block"
-                :error-message="errors.startYear?.join(',')"
-                :required="true"
-            >
-                <div class="p-inputtext-fluid">
-                    <InputText
-                        id="startYear"
-                        ref="startYearField"
-                        v-model="heritageSite.startYear"
-                        aria-describedby="start-year-help"
-                        aria-required="true"
-                        fluid
-                        @change="valueChanged"
-                        @focus="onFocusHandler"
-                        @focusout="onFocusOutHandler"
-                        @update:model-value="valueUpdated"
-                    />
-                </div>
-            </LabelledInput>
-            <LabelledInput
-                label="End Year"
-                input-name="endYear"
-                class="inline-block"
-                :error-message="errors.endYear?.join(',')"
-                :required="true"
-            >
-                <div class="p-inputtext-fluid">
-                    <InputText
-                        id="endYear"
-                        ref="endYearField"
-                        v-model="heritageSite.endYear"
-                        aria-describedby="end-year-help"
-                        aria-required="true"
-                        fluid
-                        @change="valueChanged"
-                        @focus="onFocusHandler"
-                        @focusout="onFocusOutHandler"
-                        @update:model-value="valueUpdated"
-                    />
-                </div>
-            </LabelledInput>
-
+            <DatePicker
+                id="startYear"
+                ref="startYearField"
+                v-model="startYear"
+                dateFormat="yy"
+                view="year"
+                aria-describedby="start-year-help"
+                aria-required="true"
+            />
+            <DatePicker
+                id="endYear"
+                ref="endYearField"
+                v-model="endYear"
+                dateFormat="yy"
+                view="year"
+                aria-describedby="end-year-help"
+                aria-required="true"
+            />
             <div class="inline-block">
                 <Checkbox
                     v-model="circa"
@@ -210,10 +243,10 @@ onMounted(() => {});
                 <div class="">
                     <InputText
                         id="chronologyNotes"
-                        ref="chronologyNotesField"
+                        ref="chronologyField"
                         v-model:content="heritageSite.chronologyNotes"
                         theme="snow"
-                        aria-describedby="chronology-notes-help"
+                        aria-describedby="chronology-help"
                         aria-required="true"
                         fluid
                         class="inline-block"
@@ -223,14 +256,23 @@ onMounted(() => {});
                         @update:content="valueUpdated"
                     />
                     <Button
-                        id="saveChronologyNotes"
+                        id="saveChronology"
                         label="Add"
                         class="inline-block"
-                        @click="addChronologyNotes"
+                        @click="saveChronology"
                     ></Button>
                 </div>
             </LabelledInput>
         </div>
+        <MultiValuePlaceholder
+            v-slot="slotProps"
+            label="Architect(s) / Builder(s)"
+            :showDeleteButton="true"
+            :displayValues="chronologies"
+            :deleteCallback="deleteChronologyCallback"
+        >
+            <div class="parent value">{{ slotProps.value }}</div>
+        </MultiValuePlaceholder>
     </FieldSet>
     <Fieldset
         id="architectsBuildersFieldset"
@@ -289,7 +331,7 @@ onMounted(() => {});
                 hint="Provide any additional comments about the architect/builder"
                 input-name="architectOrBuilderNotes"
                 :error-message="errors.architectOrBuilderNotes?.join(',')"
-                :required="true"
+                :required="false"
             >
                 <div class="">
                     <InputText
@@ -309,11 +351,20 @@ onMounted(() => {});
                         id="addOtherName"
                         label="Add"
                         class="inline-block"
-                        @click="addArchitectOrBuilderNotes"
+                        @click="saveArchitectOrBuilder"
                     ></Button>
                 </div>
             </LabelledInput>
         </div>
+        <MultiValuePlaceholder
+            v-slot="slotProps"
+            label="Architect(s) / Builder(s)"
+            :showDeleteButton="true"
+            :displayValues="architectsOrBuilders"
+            :deleteCallback="deleteArchitectBuilderCallback"
+        >
+            <div class="parent value">{{ slotProps.value }}</div>
+        </MultiValuePlaceholder>
     </Fieldset>
     <Fieldset
         id="relatedURLsFieldset"
@@ -371,15 +422,15 @@ onMounted(() => {});
                 label="URL"
                 hint="URL must be stable and publicly accessible"
                 input-name="url"
-                :error-message="errors.url?.join(',')"
+                :error-message="errors.urls?.join(',')"
                 :required="true"
             >
                 <div class="flex flex-row full-width">
                     <InputText
                         id="url"
                         ref="urlField"
-                        v-model="heritageSite.url"
-                        aria-describedby="architect-or-builder-notes-help"
+                        v-model="url"
+                        aria-describedby="url-help"
                         aria-required="true"
                         fluid
                         class="inline-block"
@@ -389,13 +440,22 @@ onMounted(() => {});
                         @update:model-value="valueUpdated"
                     />
                     <Button
-                        id="addOtherName"
+                        id="saveURL"
                         label="Add"
                         class="inline-block"
-                        @click="addURL"
+                        @click="saveURL"
                     ></Button>
                 </div>
             </LabelledInput>
+            <MultiValuePlaceholder
+                v-slot="slotProps"
+                label="URL(s)"
+                :showDeleteButton="true"
+                :displayValues="urls"
+                :deleteCallback="deleteURLCallback"
+            >
+                <div class="parent value">{{ slotProps.value }}</div>
+            </MultiValuePlaceholder>
         </div>
     </Fieldset>
 </template>

--- a/bcrhp/src/bcrhp/schema/HeritageSiteSchema.ts
+++ b/bcrhp/src/bcrhp/schema/HeritageSiteSchema.ts
@@ -18,29 +18,75 @@ const HeritageSiteSchema = z.object({
     uploadImage: z.array(UploadImageSchema),
     siteBoundary: z.object(), // This needs to map to a GeoJSON object
     siteBoundaryIncorrect: z.boolean().default(false), // If the geometry from the PID isn't right this flags it
-    designationDate: z.array(z.string()).max(12),
-    legislativeAct: z.array(z.string()).max(32),
-    referenceNumber: z.array(z.string()).max(80),
-    description: z.array(z.string()).max(4000),
-    heritageValue: z.array(z.string()).max(4000),
-    definingElements: z.array(z.string()).max(4000),
-    documentLocation: z.array(z.string()).max(350),
-    numberOfResources: z.array(z.string()).max(12),
-    functionCategory: z.array(z.string()).max(12),
-    heritageTheme: z.array(z.string()).max(12),
-    chronologyNotes: z.array(z.string()).max(250),
+    designationDate: z
+        .string()
+        .min(1, { message: 'Designation Date is required.' })
+        .max(12),
+    legislativeAct: z
+        .string()
+        .min(1, { message: 'Legislative Act is required.' })
+        .max(250),
+    referenceNumber: z
+        .string()
+        .min(1, { message: 'Reference Number is required.' })
+        .max(12),
+    referenceNumbers: z.array(z.string()).max(12),
+    description: z
+        .string()
+        .min(1, { message: 'Description is required.' })
+        .max(4000),
+    heritageValue: z
+        .string()
+        .min(1, { message: 'Heritage Value is required.' })
+        .max(4000),
+    definingElements: z
+        .string()
+        .min(1, { message: 'Defining Elements is required.' })
+        .max(4000),
+    documentLocation: z
+        .string()
+        .min(1, { message: 'Document Location is required.' })
+        .max(250),
+    contributingResources: z
+        .string()
+        .min(1, { message: 'Number of Contributing Resources is required.' })
+        .max(250),
+    totalContributingResources: z.array(z.string()).max(5),
+    functionCategory: z
+        .string()
+        .min(1, { message: 'Function Category is required.' })
+        .max(250),
+    functionCategories: z.array(z.string()).max(5),
+    heritageTheme: z
+        .string()
+        .min(1, { message: 'Heritage Theme is required.' })
+        .max(250),
+    heritageThemes: z.array(z.string()).max(5),
+    chronology: z
+        .string()
+        .min(1, { message: 'Chronology is required.' })
+        .max(250),
+    chronologies: z.array(z.string()).max(5),
     startYear: z.array(z.string()).max(4),
     endYear: z.array(z.string()).max(4),
-    architectOrBuilderName: z.array(z.string()).max(250),
-    architectOrBuilderNotes: z.array(z.string()).max(250),
-    architectOrBuilderType: z.array(z.string()).max(32),
+    architectOrBuilderName: z
+        .string()
+        .min(1, { message: 'Architect or Builder Name is required.' })
+        .max(250),
+    architectOrBuilderNotes: z.string().max(4000),
+    architectOrBuilderType: z
+        .string()
+        .min(1, { message: 'Architect or Builder Type is required.' })
+        .max(250),
+    architectsOrBuilders: z.array(z.string()).max(5),
     urlType: z.array(z.string()).max(250),
-    urlText: z.array(z.string()).max(250),
-    linkText: z.array(z.string()).max(250),
-    url: z.array(z.string()).max(250),
+    urlText: z.string().min(1, { message: 'URL Type is required.' }).max(250),
+    linkText: z.string().min(1, { message: 'URL Text is required.' }).max(250),
+    url: z.string().min(1, { message: 'URL is required.' }).max(250),
+    urls: z.array(z.string()).max(5),
     otherName: z.array(z.string()).max(12),
-    documentDescription: z.array(z.string()).max(250),
-    submissionNotes: z.array(z.string()).max(250),
+    documentDescription: z.string().max(250),
+    submissionNotes: z.string().max(250),
 });
 
 const requiredHeritageSiteSchema = HeritageSiteSchema.partial({
@@ -69,22 +115,29 @@ class HeritageSite implements HeritageSiteType {
         this.legislativeAct = '';
         this.showInactiveHistoricActs = false;
         this.referenceNumber = '';
+        this.referenceNumbers = [];
         this.description = '';
         this.heritageValue = '';
         this.definingElements = '';
         this.documentLocation = '';
-        this.numberOfResources = '';
+        this.contributingResources = '';
+        this.totalContributingResources = [];
         this.functionCategory = '';
+        this.functionCategories = [];
         this.heritageTheme = '';
-        this.chronologyNotes = '';
+        this.heritageThemes = [];
+        this.chronology = '';
+        this.chronologies = [];
         this.startYear = '';
         this.endYear = '';
         this.architectOrBuilderName = '';
         this.architectOrBuilderNotes = '';
         this.architectOrBuilderType = '';
+        this.architectsOrBuilders = [];
         this.urlType = '';
         this.linkText = '';
         this.url = '';
+        this.urls = [];
         this.otherName = '';
         this.documentDescription = '';
         this.submissionNotes = '';
@@ -102,22 +155,29 @@ class HeritageSite implements HeritageSiteType {
     legislativeAct: string;
     showInactiveHistoricActs: boolean;
     referenceNumber: string;
+    referenceNumbers: string[];
     description: string;
     heritageValue: string;
     definingElements: string;
     documentLocation: string;
-    numberOfResources: string;
+    contributingResources: string;
+    totalContributingResources: string[];
     functionCategory: string;
+    functionCategories: string[];
     heritageTheme: string;
-    chronologyNotes: string;
+    heritageThemes: string[];
+    chronology: string;
+    chronologies: string[];
     startYear: string;
     endYear: string;
     architectOrBuilderName: string;
     architectOrBuilderNotes: string;
     architectOrBuilderType: string;
+    architectsOrBuilders: string[];
     urlType: string;
     linkText: string;
     url: string;
+    urls: string[];
     otherName: string;
     documentDescription: string;
     submissionNotes: string;

--- a/bcrhp/src/bcrhp/schema/UploadImageSchema.ts
+++ b/bcrhp/src/bcrhp/schema/UploadImageSchema.ts
@@ -1,13 +1,25 @@
 import { z } from 'zod';
 
 const UploadImageSchema = z.object({
-    imageType: z.array(z.string()).max(250),
-    imageView: z.array(z.string()).max(250),
-    imageFeatures: z.array(z.string()).max(250),
-    imageDate: z.array(z.string()).max(250),
-    imageDescription: z.array(z.string()).max(250),
-    photographer: z.array(z.string()).max(250),
-    copyright: z.array(z.string()).max(250),
+    imageType: z
+        .string()
+        .min(1, { message: 'Image Type is required.' })
+        .max(250),
+    imageView: z
+        .string()
+        .min(1, { message: 'Image View is required.' })
+        .max(250),
+    imageFeatures: z.string().max(250),
+    imageDate: z
+        .string()
+        .min(1, { message: 'Image Date is required.' })
+        .max(250),
+    imageDescription: z
+        .string()
+        .min(1, { message: 'Image Description is required.' })
+        .max(250),
+    photographer: z.string().max(250),
+    copyright: z.string().max(250),
 });
 
 const requiredUploadImageSchema = UploadImageSchema.partial({});

--- a/components.d.ts
+++ b/components.d.ts
@@ -8,6 +8,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    DatePicker: typeof import('primevue/datepicker')['default']
     Fieldset: typeof import('primevue/fieldset')['default']
     FileUpload: typeof import('primevue/fileupload')['default']
     RouterLink: typeof import('vue-router')['RouterLink']


### PR DESCRIPTION
This PR does the following things:

1. Add the Step11_ReviewSubmission page which displays the information entered in each step (not yet fully functional)
2. Implement the DatePicker component where it was missing (Step7_Images and Step9_SiteDetails)
3. Implement the MultiValuePlaceholder component where it was missing (Step5_RecognitionDetails,  Step7_Images, Step8_SiteClassification and Step9_SiteDetails)
4. Fix minor bugs in components (mostly misspelled variables)

Known bugs:

1. The 'Add' button on Step5_RecognitionDetails, Step7_Images, Step8_SiteClassification and Step9_SiteDetails does not get properly disabled when no values are entered
2. It's possible to add an empty item due to the 'Add' button always being enabled
3. CivicAddress and UploadImage are not yet shown on the Step11_ReviewSubmission page
4. It's not possible to add multiple values at once. For example, on Step8_SiteClassification, when adding the Number of Resources and then selecting several checkboxes, the value of the checkboxes will not be saved. This will be fixed in a future ticket when individual schema is created for each step