### PR TITLE
Add link to LHS toolbar. Currently duplicating.

### DIFF
--- a/bcrhp/settings.py
+++ b/bcrhp/settings.py
@@ -215,7 +215,7 @@ INSTALLED_APPS += ("arches.app",)
 
 DJANGO_VITE = {
     "default": {
-        "dev_mode": True,
+        "dev_mode": False,
         # "static_url_prefix": "/bcrhp/static",
         "static_url_prefix": "/",
     }

--- a/bcrhp/templates/views/search.htm
+++ b/bcrhp/templates/views/search.htm
@@ -12,4 +12,21 @@
 {% block main_content %}
 {{ block.super }}
 {% csrf_token %}
+
 {% endblock main_content %}
+
+{% block navbar %}
+{{ block.super }}
+<ul class="list-group" aria-label="Site Submissions menu">
+    <!-- Site Submissions -->
+    <li>
+        <a href="/bcrhp/submissions" aria-labelledby="submissions-link-label" target="site_submissions">
+            <i class="fa fa-file-lines"></i>
+            <span class="menu-title">
+                                    <strong id="submissions-link-label">Site Submissions</strong>
+                                </span>
+        </a>
+    </li>
+</ul>
+{% endblock navbar %}
+


### PR DESCRIPTION
- Adds a link to the LHS toolbar to access the Site Submissions menu.
- Sets the build default to Webpack for CI/CD.
