### PR TITLE
Create individual validation schema for each step

### DIFF
--- a/bcrhp/src/bcrhp/pages/NewSite.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite.vue
@@ -19,7 +19,7 @@ import SpatialLocation from './steps/Step3_SpatialLocation.vue';
 import SiteNames from './steps/Step4_SiteNames.vue';
 import RecognitionDetails from './steps/Step5_RecognitionDetails.vue';
 import SOS from './steps/Step6_SOS.vue';
-import UploadImage from './steps/Step7_UploadImage.vue';
+import SiteImages from './steps/Step7_SiteImages.vue';
 import SiteClassification from './steps/Step8_SiteClassification.vue';
 import SiteDetails from './steps/Step9_SiteDetails.vue';
 import SupportingDocuments from './steps/Step10_SupportingDocuments.vue';
@@ -296,7 +296,7 @@ const showDebug = ref(false);
                                 2MB. Include illustrations, plans, etc. in the
                                 Supporting Documents section
                             </p>
-                            <UploadImage ref="step7"></UploadImage>
+                            <SiteImages ref="step7"></SiteImages>
                             <div class="">
                                 <StepperNavigation
                                     :step-number="6"
@@ -447,9 +447,11 @@ li {
     word-wrap: anywhere;
     color: darkgray;
 }
+
 .show-debug {
     display: inline-block !important;
 }
+
 .debug-toggle {
     position: absolute;
     top: 0;

--- a/bcrhp/src/bcrhp/pages/steps/Step11_ReviewSubmission.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step11_ReviewSubmission.vue
@@ -28,22 +28,34 @@ const heritageSite: typeof HeritageSite = inject(
     </div>
     <div>
         <p class="mb-2 underline font-bold">Official Recognition Details</p>
-        <p>Start Date {{ heritageSite.commonName }}</p>
-        <p>Legislative Act {{ heritageSite.commonName }}</p>
         <div
-            v-for="number in heritageSite.referenceNumbers"
-            :key="number"
+            v-for="recognitionDetail in heritageSite.recognitionDetails
+                .totalRecognitionDetails"
+            :key="recognitionDetail"
         >
-            <p>Reference Number {{ number }}</p>
+            <p>Start Date {{ recognitionDetail.designationDate }}</p>
+            <p>Legislative Act {{ recognitionDetail.legislativeAct }}</p>
+            <p>Reference Number {{ recognitionDetail.referenceNumber }}</p>
         </div>
     </div>
     <div>
         <p class="mb-2 underline font-bold">Statement of Significance</p>
-        <p>Description <span v-html="heritageSite.description"> </span></p>
-        <p>Heritage Value <span v-html="heritageSite.heritageValue"> </span></p>
+        <p>
+            Description
+            <span v-html="heritageSite.statementOfSignificance.description">
+            </span>
+        </p>
+        <p>
+            Heritage Value
+            <span v-html="heritageSite.statementOfSignificance.heritageValue">
+            </span>
+        </p>
         <p>
             Character Defining Elements
-            <span v-html="heritageSite.definingElements"> </span>
+            <span
+                v-html="heritageSite.statementOfSignificance.definingElements"
+            >
+            </span>
         </p>
         <p>Document Location {{ heritageSite.documentLocation }}</p>
     </div>
@@ -65,48 +77,84 @@ const heritageSite: typeof HeritageSite = inject(
             <p class="mb-2 underline font-bold">Site Details</p>
             <p>Heritage Class</p>
             <div
-                v-for="contributingResource in heritageSite.totalContributingResources"
-                :key="contributingResource"
+                v-for="heritageClass in heritageSite.siteClassification
+                    .heritageClasses"
+                :key="heritageClass"
             >
-                <p>{{ contributingResource }}</p>
+                <ol class="list-decimal ml-4">
+                    <li>
+                        {{ heritageClass.heritageCategory }},
+                        {{ heritageClass.ownership }} ({{
+                            heritageClass.contributingResources.name
+                        }})
+                    </li>
+                </ol>
             </div>
             <p>Heritage Function</p>
             <div
-                v-for="heritageTheme in heritageSite.heritageThemes"
-                :key="heritageTheme"
+                v-for="heritageFunction in heritageSite.siteClassification
+                    .heritageFunctions"
+                :key="heritageFunction"
             >
-                <p>{{ heritageTheme }}</p>
+                <ol class="list-decimal ml-4">
+                    <li>
+                        {{ heritageFunction.functionCategory.name }} ({{
+                            heritageFunction.functionCategoryType
+                        }})
+                    </li>
+                </ol>
             </div>
             <p>Heritage Theme</p>
             <div
-                v-for="functionCategory in heritageSite.functionCategories"
-                :key="functionCategory"
+                v-for="heritageTheme in heritageSite.siteClassification
+                    .heritageThemes"
+                :key="heritageTheme"
             >
-                <p>{{ functionCategory }}</p>
+                <ol class="list-decimal ml-4">
+                    <p>{{ heritageTheme.name }}</p>
+                </ol>
             </div>
         </div>
         <div>
             <p class="mb-2 underline font-bold">Site Classification</p>
             <p>Chronology</p>
             <div
-                v-for="chronology in heritageSite.chronologies"
+                v-for="chronology in heritageSite.siteDetails.chronologies"
                 :key="chronology"
             >
-                <p>{{ chronology }}</p>
+                <ol class="list-decimal ml-4">
+                    <li>
+                        {{ chronology.eventType }}, {{ chronology.circa }}
+                        {{ chronology.startYear }}-{{ chronology.endYear }}
+                        <p>{{ chronology.chronologyNotes }}</p>
+                    </li>
+                </ol>
             </div>
             <p>Architects / Builders</p>
             <div
-                v-for="architectOrBuilder in heritageSite.architectsOrBuilders"
+                v-for="architectOrBuilder in heritageSite.siteDetails
+                    .architectsOrBuilders"
                 :key="architectOrBuilder"
             >
-                <p>{{ architectOrBuilder }}</p>
+                <ol class="list-decimal ml-4">
+                    <li>
+                        {{ architectOrBuilder.architectOrBuilderType.name }}
+                        {{ architectOrBuilder.architectOrBuilderName }}
+                    </li>
+                    <p>{{ architectOrBuilder.architectOrBuilderNotes }}</p>
+                </ol>
             </div>
             <p>URLs</p>
             <div
-                v-for="url in heritageSite.urls"
+                v-for="url in heritageSite.siteDetails.urls"
                 :key="url"
             >
-                <p>{{ url }}</p>
+                <ol class="list-decimal ml-4">
+                    <li>
+                        {{ url.urlType.name }}: {{ url.url }}
+                        <p>Link Text: {{ url.linkText }}</p>
+                    </li>
+                </ol>
             </div>
         </div>
         <div>

--- a/bcrhp/src/bcrhp/pages/steps/Step11_ReviewSubmission.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step11_ReviewSubmission.vue
@@ -34,7 +34,7 @@ const heritageSite: typeof HeritageSite = inject(
             :key="recognitionDetail"
         >
             <p>Start Date {{ recognitionDetail.designationDate }}</p>
-            <p>Legislative Act {{ recognitionDetail.legislativeAct }}</p>
+            <p>Legislative Act {{ recognitionDetail.legislativeAct?.name }}</p>
             <p>Reference Number {{ recognitionDetail.referenceNumber }}</p>
         </div>
     </div>
@@ -62,7 +62,7 @@ const heritageSite: typeof HeritageSite = inject(
     <div>
         <p class="mb-2 underline font-bold">Images</p>
         <div
-            v-for="image in heritageSite.uploadImage"
+            v-for="image in heritageSite.siteImages"
             :key="image"
         >
             <p>Type {{ image.imageType }}</p>

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -12,7 +12,7 @@ import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePl
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import LabelledCheckboxInput from '@/bcgov_arches_common/components/labelledinput/LabelledCheckbox.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
-import { requiredHeritageSiteSchema } from '@/bcrhp/schema/HeritageSiteSchema.ts';
+import { requiredRecognitionDetailsSchema } from '@/bcrhp/schema/RecognitionDetailsSchema.ts';
 import type { ZodError } from 'zod';
 
 const heritageSite: typeof HeritageSite = inject(
@@ -23,8 +23,10 @@ const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
 
+const designationDate = ref();
+const legislativeAct = ref('');
 const referenceNumber = ref('');
-const referenceNumbers = ref([] as Array<string>);
+const totalRecognitionDetails = ref([] as Array<string>);
 const addOtherReferenceNumberDisabled = ref(false);
 
 // These names need to match the Zog schema
@@ -48,10 +50,11 @@ const isValid = () => {
     return valid;
 };
 
-const updateAddOtherRefNumber = function () {
+const updateAddOtherRecognitionDetails = function () {
     addOtherReferenceNumberDisabled.value =
-        referenceNumber.value.length < 1 ||
-        heritageSiteRef.value.referenceNumbers.length > 4;
+        totalRecognitionDetails.value.length < 1 ||
+        heritageSiteRef.value.recognitionDetails.totalRecognitionDetails
+            .length > 4;
 };
 
 const valueUpdated = function (value: string | undefined) {
@@ -76,12 +79,13 @@ const onFocusOutHandler = function (event: Event) {
 
 const validateField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
+
     const key: keyof typeof HeritageSite =
         field.id as keyof typeof HeritageSite;
-    console.log(key);
-    const fieldValidation = requiredHeritageSiteSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
-    );
+    const fieldValidation = requiredRecognitionDetailsSchema.shape[
+        key
+    ].safeParse(heritageSiteRef.value[key]);
+
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
         errors.value[key] = [];
@@ -91,19 +95,28 @@ const validateField = function (field: HTMLInputElement) {
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
     }
+
     return fieldValidation.success;
 };
 
-const saveReferenceNumber = function () {
-    console.log('saveReferenceNumber');
-    heritageSiteRef.value.referenceNumbers.push(referenceNumber.value);
-    referenceNumber.value = '';
-    updateAddOtherRefNumber();
+const saveRecognitionDetails = function () {
+    console.log('saveRecognitionDetails');
+    heritageSiteRef.value.recognitionDetails.totalRecognitionDetails.push({
+        designationDate: designationDate.value,
+        legislativeAct: legislativeAct.value,
+        referenceNumber: referenceNumber.value,
+    });
+
+    updateAddOtherRecognitionDetails();
 };
 
-const deleteReferenceNumberCallback = function (index: number) {
-    heritageSiteRef.value.referenceNumbers.splice(index, 1);
-    updateAddOtherRefNumber();
+const deleteRecognitionDetailsCallback = function (index: number) {
+    heritageSiteRef.value.recognitionDetails.totalRecognitionDetails.splice(
+        index,
+        1,
+    );
+
+    updateAddOtherRecognitionDetails();
 };
 
 let validateFields = false;
@@ -113,8 +126,10 @@ let validateFields = false;
 defineExpose({ isValid });
 
 onMounted(() => {
-    heritageSiteRef.value.referenceNumbers = referenceNumbers;
-    updateAddOtherRefNumber();
+    heritageSiteRef.value.recognitionDetails.totalRecognitionDetails =
+        totalRecognitionDetails;
+
+    updateAddOtherRecognitionDetails();
 });
 </script>
 <template>
@@ -130,7 +145,8 @@ onMounted(() => {
                 <DatePicker
                     id="designationDate"
                     ref="designationDateField"
-                    v-model="heritageSite.designationDate"
+                    v-model="designationDate"
+                    dateFormat="dd/mm/yy"
                     aria-describedby="designation-date-help"
                     aria-required="true"
                 />
@@ -147,7 +163,7 @@ onMounted(() => {
                 <InputText
                     id="legislativeAct"
                     ref="legislativeActField"
-                    v-model="heritageSite.legislativeAct"
+                    v-model="legislativeAct"
                     aria-describedby="legislative-act-help"
                     aria-required="true"
                     class="inline-block"
@@ -184,7 +200,7 @@ onMounted(() => {
             label="Reference Number"
             hint="The bylaw or resolution number"
             input-name="referenceNumber"
-            :error-message="errors.referenceNumbers?.join(',')"
+            :error-message="errors.totalRecognitionDetails?.join(',')"
             :required="true"
         >
             <div>
@@ -201,23 +217,30 @@ onMounted(() => {
                     @focusout="onFocusOutHandler"
                     @update:model-value="valueUpdated"
                 />
-                <Button
-                    id="saveReferenceNumber"
-                    label="Add"
-                    class="inline-block"
-                    :aria-disabled="addOtherReferenceNumberDisabled"
-                    @click="saveReferenceNumber"
-                ></Button>
             </div>
+            <Button
+                id="saveRecognitionDetails"
+                label="Add"
+                class="inline-block"
+                :aria-disabled="addOtherReferenceNumberDisabled"
+                @click="saveRecognitionDetails"
+            ></Button>
         </LabelledInput>
         <MultiValuePlaceholder
             v-slot="slotProps"
             label="Reference Number"
             :showDeleteButton="true"
-            :displayValues="referenceNumbers"
-            :deleteCallback="deleteReferenceNumberCallback"
+            :displayValues="totalRecognitionDetails"
+            :deleteCallback="deleteRecognitionDetailsCallback"
         >
-            <div class="parent value">{{ slotProps.value }}</div>
+            <div
+                v-for="slot in slotProps"
+                :key="slot"
+                class="parent value"
+            >
+                {{ slot.designationDate }} {{ slot.legislativeAct }}
+                {{ slot.referenceNumber }}
+            </div>
         </MultiValuePlaceholder>
     </FieldSet>
 </template>

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -7,6 +7,7 @@ import InputText from 'primevue/inputtext';
 import Checkbox from 'primevue/checkbox';
 import Button from 'primevue/button';
 import DatePicker from 'primevue/datepicker';
+import Dropdown from 'primevue/dropdown';
 
 import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePlaceholder/MultiValuePlaceholder.vue';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
@@ -21,8 +22,12 @@ const heritageSite: typeof HeritageSite = inject(
 const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
-const errors: Ref<FormErrors> = ref<FormErrors>({});
 
+const errors: Ref<FormErrors> = ref<FormErrors>({});
+const legislativeActOptions = ref([
+    { name: 'Legislative Act 1', code: 'legislative_act_1' },
+    { name: 'Legislative Act 2', code: 'legislative_act_2' },
+]);
 const designationDate = ref();
 const legislativeAct = ref('');
 const referenceNumber = ref('');
@@ -160,17 +165,18 @@ onMounted(() => {
             :required="true"
         >
             <div class="p-inputtext-fluid flex">
-                <InputText
+                <Dropdown
                     id="legislativeAct"
                     ref="legislativeActField"
                     v-model="legislativeAct"
+                    optionLabel="name"
+                    optionValue="code"
+                    placeholder="Select Legislative Act"
+                    :options="legislativeActOptions"
                     aria-describedby="legislative-act-help"
                     aria-required="true"
-                    class="inline-block"
                     fluid
-                    @change="valueChanged"
-                    @focus="onFocusHandler"
-                    @focusout="onFocusOutHandler"
+                    class="w-full md:w-14rem"
                     @update:model-value="valueUpdated"
                 />
                 <div class="inline-block">
@@ -238,7 +244,7 @@ onMounted(() => {
                 :key="slot"
                 class="parent value"
             >
-                {{ slot.designationDate }} {{ slot.legislativeAct }}
+                {{ slot.designationDate }} {{ slot.legislativeAct?.name }}
                 {{ slot.referenceNumber }}
             </div>
         </MultiValuePlaceholder>

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -13,7 +13,11 @@ import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePl
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import LabelledCheckboxInput from '@/bcgov_arches_common/components/labelledinput/LabelledCheckbox.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
-import { requiredRecognitionDetailsSchema } from '@/bcrhp/schema/RecognitionDetailsSchema.ts';
+import {
+    RecognitionDetails,
+    requiredRecognitionDetailsSchema,
+} from '@/bcrhp/schema/RecognitionDetailsSchema.ts';
+
 import type { ZodError } from 'zod';
 
 const heritageSite: typeof HeritageSite = inject(
@@ -85,11 +89,11 @@ const onFocusOutHandler = function (event: Event) {
 const validateField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
 
-    const key: keyof typeof HeritageSite =
-        field.id as keyof typeof HeritageSite;
+    const key: keyof typeof RecognitionDetails =
+        field.id as keyof typeof RecognitionDetails;
     const fieldValidation = requiredRecognitionDetailsSchema.shape[
         key
-    ].safeParse(heritageSiteRef.value[key]);
+    ].safeParse(heritageSiteRef.value.recognitionDetails[key]);
 
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -170,7 +174,6 @@ onMounted(() => {
                     ref="legislativeActField"
                     v-model="legislativeAct"
                     optionLabel="name"
-                    optionValue="code"
                     placeholder="Select Legislative Act"
                     :options="legislativeActOptions"
                     aria-describedby="legislative-act-help"

--- a/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
@@ -69,7 +69,7 @@ const validateField = function (field: HTMLInputElement) {
         field.id as keyof typeof StatementOfSignificance;
     const fieldValidation = requiredStatementOfSignificanceSchema.shape[
         key
-    ].safeParse(heritageSiteRef.value.statementOfSignificance[key]);
+    ].safeParse(heritageSiteRef.value[key]);
 
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');

--- a/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
@@ -69,7 +69,7 @@ const validateField = function (field: HTMLInputElement) {
         field.id as keyof typeof StatementOfSignificance;
     const fieldValidation = requiredStatementOfSignificanceSchema.shape[
         key
-    ].safeParse(heritageSiteRef.value[key]);
+    ].safeParse(heritageSiteRef.value.statementOfSignificance[key]);
 
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');

--- a/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
@@ -6,7 +6,10 @@ import InputText from 'primevue/inputtext';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import Editor from 'primevue/editor';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
-import { requiredStatementOfSignificanceSchema } from '@/bcrhp/schema/StatementOfSignificanceSchema.ts';
+import {
+    StatementOfSignificance,
+    requiredStatementOfSignificanceSchema,
+} from '@/bcrhp/schema/StatementOfSignificanceSchema.ts';
 import type { ZodError } from 'zod';
 
 const heritageSite: typeof HeritageSite = inject(
@@ -62,11 +65,11 @@ const onFocusOutHandler = function (event: Event) {
 const validateField = function (field: HTMLInputElement) {
     console.log(`ID: ${field}`);
 
-    const key: keyof typeof HeritageSite =
-        field.id as keyof typeof HeritageSite;
+    const key: keyof typeof StatementOfSignificance =
+        field.id as keyof typeof StatementOfSignificance;
     const fieldValidation = requiredStatementOfSignificanceSchema.shape[
         key
-    ].safeParse(heritageSiteRef.value[key]);
+    ].safeParse(heritageSiteRef.value.statementOfSignificance[key]);
 
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');

--- a/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
@@ -6,7 +6,7 @@ import InputText from 'primevue/inputtext';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import Editor from 'primevue/editor';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
-import { requiredHeritageSiteSchema } from '@/bcrhp/schema/HeritageSiteSchema.ts';
+import { requiredStatementOfSignificanceSchema } from '@/bcrhp/schema/StatementOfSignificanceSchema.ts';
 import type { ZodError } from 'zod';
 
 const heritageSite: typeof HeritageSite = inject(
@@ -61,11 +61,13 @@ const onFocusOutHandler = function (event: Event) {
 
 const validateField = function (field: HTMLInputElement) {
     console.log(`ID: ${field}`);
+
     const key: keyof typeof HeritageSite =
         field.id as keyof typeof HeritageSite;
-    const fieldValidation = requiredHeritageSiteSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
-    );
+    const fieldValidation = requiredStatementOfSignificanceSchema.shape[
+        key
+    ].safeParse(heritageSiteRef.value[key]);
+
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
         errors.value[key] = [];
@@ -75,6 +77,7 @@ const validateField = function (field: HTMLInputElement) {
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
     }
+
     return fieldValidation.success;
 };
 
@@ -99,7 +102,7 @@ onMounted(() => {});
                 <Editor
                     id="description"
                     ref="descriptionField"
-                    v-model="heritageSite.description"
+                    v-model="heritageSite.statementOfSignificance.description"
                     theme="snow"
                     aria-describedby="description-help"
                     aria-required="true"
@@ -122,7 +125,7 @@ onMounted(() => {});
                 <Editor
                     id="heritageValue"
                     ref="heritageValueField"
-                    v-model="heritageSite.heritageValue"
+                    v-model="heritageSite.statementOfSignificance.heritageValue"
                     theme="snow"
                     aria-describedby="heritage-value-help"
                     aria-required="true"
@@ -145,7 +148,9 @@ onMounted(() => {});
                 <Editor
                     id="definingElements"
                     ref="definingElementsField"
-                    v-model="heritageSite.definingElements"
+                    v-model="
+                        heritageSite.statementOfSignificance.definingElements
+                    "
                     theme="snow"
                     aria-describedby="defining-elements-help"
                     aria-required="true"
@@ -168,7 +173,9 @@ onMounted(() => {});
                 <InputText
                     id="documentLocation"
                     ref="documentLocationField"
-                    v-model="heritageSite.documentLocation"
+                    v-model="
+                        heritageSite.statementOfSignificance.documentLocation
+                    "
                     aria-describedby="document-location-help"
                     aria-required="true"
                     fluid

--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -71,7 +71,7 @@ const validateField = function (field: HTMLInputElement) {
 
     const key: keyof typeof SiteImages = field.id as keyof typeof SiteImages;
     const fieldValidation = requiredSiteImagesSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.siteImages[key],
     );
 
     if (fieldValidation.success) {

--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -8,7 +8,10 @@ import DatePicker from 'primevue/datepicker';
 
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
-import { requiredUploadImageSchema } from '@/bcrhp/schema/UploadImageSchema.ts';
+import {
+    SiteImages,
+    requiredSiteImagesSchema,
+} from '@/bcrhp/schema/SiteImagesSchema.ts';
 import type { ZodError } from 'zod';
 
 const heritageSite: typeof HeritageSite = inject(
@@ -66,10 +69,9 @@ const onFocusOutHandler = function (event: Event) {
 const validateField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
 
-    const key: keyof typeof HeritageSite =
-        field.id as keyof typeof HeritageSite;
-    const fieldValidation = requiredUploadImageSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+    const key: keyof typeof SiteImages = field.id as keyof typeof SiteImages;
+    const fieldValidation = requiredSiteImagesSchema.shape[key].safeParse(
+        heritageSiteRef.value.siteImages[key],
     );
 
     if (fieldValidation.success) {
@@ -120,7 +122,7 @@ onMounted(() => {});
                 <InputText
                     id="imageType"
                     ref="imageTypeField"
-                    v-model="heritageSite.uploadImage.imageType"
+                    v-model="heritageSite.siteImages.imageType"
                     aria-describedby="image-type-help"
                     aria-required="true"
                     fluid
@@ -142,7 +144,7 @@ onMounted(() => {});
                 <InputText
                     id="imageView"
                     ref="imageViewField"
-                    v-model="heritageSite.uploadImage.imageView"
+                    v-model="heritageSite.siteImages.imageView"
                     aria-describedby="image-view-help"
                     aria-required="true"
                     fluid
@@ -165,7 +167,7 @@ onMounted(() => {});
             <InputText
                 id="imageFeatures"
                 ref="imageFeaturesField"
-                v-model="heritageSite.uploadImage.imageFeatures"
+                v-model="heritageSite.siteImages.imageFeatures"
                 aria-describedby="image-features-help"
                 aria-required="true"
                 fluid
@@ -187,7 +189,7 @@ onMounted(() => {});
         <DatePicker
             id="imageDate"
             ref="imageDateField"
-            v-model="heritageSite.uploadImage.imageDate"
+            v-model="heritageSite.siteImages.imageDate"
             aria-describedby="image-date-help"
             aria-required="true"
         />
@@ -203,7 +205,7 @@ onMounted(() => {});
             <Editor
                 id="imageDescription"
                 ref="imageDescriptionField"
-                v-model="heritageSite.uploadImage.imageDescription"
+                v-model="heritageSite.siteImages.imageDescription"
                 theme="snow"
                 aria-describedby="image-description-help"
                 aria-required="true"
@@ -225,7 +227,7 @@ onMounted(() => {});
             <InputText
                 id="photographer"
                 ref="photographerField"
-                v-model="heritageSite.uploadImage.photographer"
+                v-model="heritageSite.siteImages.photographer"
                 aria-describedby="image-features-help"
                 aria-required="true"
                 fluid
@@ -247,7 +249,7 @@ onMounted(() => {});
             <InputText
                 id="copyright"
                 ref="copyrightField"
-                v-model="heritageSite.uploadImage.copyright"
+                v-model="heritageSite.siteImages.copyright"
                 aria-describedby="copyright-help"
                 aria-required="true"
                 fluid

--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -71,7 +71,7 @@ const validateField = function (field: HTMLInputElement) {
 
     const key: keyof typeof SiteImages = field.id as keyof typeof SiteImages;
     const fieldValidation = requiredSiteImagesSchema.shape[key].safeParse(
-        heritageSiteRef.value.siteImages[key],
+        heritageSiteRef.value[key],
     );
 
     if (fieldValidation.success) {

--- a/bcrhp/src/bcrhp/pages/steps/Step7_UploadImage.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_UploadImage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useTemplateRef, ref, onMounted } from 'vue';
+import { useTemplateRef, inject, ref, onMounted } from 'vue';
 import type { Ref } from 'vue';
 
 import InputText from 'primevue/inputtext';
@@ -7,14 +7,15 @@ import Editor from 'primevue/editor';
 import DatePicker from 'primevue/datepicker';
 
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
-import type { UploadImage } from '@/bcrhp/schema/UploadImageSchema.ts';
-import { getUploadImage } from '@/bcrhp/schema/UploadImageSchema.ts';
+import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
 import { requiredUploadImageSchema } from '@/bcrhp/schema/UploadImageSchema.ts';
 import type { ZodError } from 'zod';
 
-const uploadImage: typeof UploadImage = getUploadImage();
-const uploadImageRef: Ref<typeof UploadImage> = ref(uploadImage);
-type FormErrors = Partial<Record<keyof typeof UploadImage, string[]>>;
+const heritageSite: typeof HeritageSite = inject(
+    'heritageSite',
+) as typeof HeritageSite;
+const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
+type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
 
 // These names need to match the Zog schema
@@ -64,10 +65,13 @@ const onFocusOutHandler = function (event: Event) {
 
 const validateField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
-    const key: keyof typeof UploadImage = field.id as keyof typeof UploadImage;
+
+    const key: keyof typeof HeritageSite =
+        field.id as keyof typeof HeritageSite;
     const fieldValidation = requiredUploadImageSchema.shape[key].safeParse(
-        uploadImageRef.value[key],
+        heritageSiteRef.value[key],
     );
+
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
         errors.value[key] = [];
@@ -77,6 +81,7 @@ const validateField = function (field: HTMLInputElement) {
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
     }
+
     return fieldValidation.success;
 };
 
@@ -115,7 +120,7 @@ onMounted(() => {});
                 <InputText
                     id="imageType"
                     ref="imageTypeField"
-                    v-model="uploadImage.imageType"
+                    v-model="heritageSite.uploadImage.imageType"
                     aria-describedby="image-type-help"
                     aria-required="true"
                     fluid
@@ -137,7 +142,7 @@ onMounted(() => {});
                 <InputText
                     id="imageView"
                     ref="imageViewField"
-                    v-model="uploadImage.imageView"
+                    v-model="heritageSite.uploadImage.imageView"
                     aria-describedby="image-view-help"
                     aria-required="true"
                     fluid
@@ -160,7 +165,7 @@ onMounted(() => {});
             <InputText
                 id="imageFeatures"
                 ref="imageFeaturesField"
-                v-model="uploadImage.imageFeatures"
+                v-model="heritageSite.uploadImage.imageFeatures"
                 aria-describedby="image-features-help"
                 aria-required="true"
                 fluid
@@ -182,7 +187,7 @@ onMounted(() => {});
         <DatePicker
             id="imageDate"
             ref="imageDateField"
-            v-model="uploadImage.imageDate"
+            v-model="heritageSite.uploadImage.imageDate"
             aria-describedby="image-date-help"
             aria-required="true"
         />
@@ -198,7 +203,7 @@ onMounted(() => {});
             <Editor
                 id="imageDescription"
                 ref="imageDescriptionField"
-                v-model="uploadImage.imageDescription"
+                v-model="heritageSite.uploadImage.imageDescription"
                 theme="snow"
                 aria-describedby="image-description-help"
                 aria-required="true"
@@ -220,7 +225,7 @@ onMounted(() => {});
             <InputText
                 id="photographer"
                 ref="photographerField"
-                v-model="uploadImage.photographer"
+                v-model="heritageSite.uploadImage.photographer"
                 aria-describedby="image-features-help"
                 aria-required="true"
                 fluid
@@ -242,7 +247,7 @@ onMounted(() => {});
             <InputText
                 id="copyright"
                 ref="copyrightField"
-                v-model="uploadImage.copyright"
+                v-model="heritageSite.uploadImage.copyright"
                 aria-describedby="copyright-help"
                 aria-required="true"
                 fluid

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -1,15 +1,21 @@
 <script setup lang="ts">
-import { useTemplateRef, inject, ref, onMounted } from 'vue';
+import { inject, ref, onMounted } from 'vue';
 import type { Ref } from 'vue';
 
 import FieldSet from 'primevue/fieldset';
 import Button from 'primevue/button';
 import Checkbox from 'primevue/checkbox';
+import RadioButton from 'primevue/radiobutton';
 import Dropdown from 'primevue/dropdown';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePlaceholder/MultiValuePlaceholder.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
-import { requiredSiteClassificationSchema } from '@/bcrhp/schema/SiteClassificationSchema.ts';
+import {
+    requiredSiteClassificationSchema,
+    requiredHeritageClassSchema,
+    requiredHeritageFunctionSchema,
+    requiredHeritageThemeSchema,
+} from '@/bcrhp/schema/SiteClassificationSchema.ts';
 import type { ZodError } from 'zod';
 
 const heritageSite: typeof HeritageSite = inject(
@@ -19,13 +25,6 @@ const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
-const contributingResourcesOptions = ref([
-    { name: '1', code: 1 },
-    { name: '2', code: 2 },
-    { name: '3', code: 3 },
-    { name: '4', code: 4 },
-    { name: '5', code: 5 },
-]);
 const functionCategoryOptions = ref([
     { name: 'Market', code: 'market' },
     { name: 'Eating or Drinking Establishment', code: 'eating_or_drinking' },
@@ -34,7 +33,7 @@ const functionThemeOptions = ref([
     { name: 'Learning and the Arts', code: 'learning_and_arts' },
     { name: 'Architecture and Design', code: 'architecture_and_design' },
 ]);
-const contributingResources = ref({ name: '', code: 0 });
+const contributingResources = ref('');
 const heritageClasses = ref([] as Array<string>);
 const functionCategory = ref({ name: '', code: '' });
 const heritageFunctions = ref([] as Array<string>);
@@ -43,62 +42,106 @@ const heritageThemes = ref([] as Array<string>);
 const addContributingResourcesDisabled = ref(false);
 const addOtherFunctionCategoryDisabled = ref(false);
 const addOtherHeritageSiteDisabled = ref(false);
-// const otherNames = ref(string[]);
-
-// These names need to match the Zog schema
-const fields = {
-    numberOfResourcesField: useTemplateRef('numberOfResourcesField'),
-    heritageThemeField: useTemplateRef('heritageThemeField'),
-};
 const heritageCategory = ref();
 const ownership = ref();
 const functionCategoryType = ref();
 
-const isValid = () => {
-    // We don't want to validate fields the first time we show the step
-    if (!validateFields) {
-        validateFields = true;
-        return true;
-    }
-    let valid = true;
+const valueChanged = function (event: Event, schema: string) {
+    console.log(event);
 
-    for (const field of Object.values(fields) as Array<Ref>) {
-        valid = validateField(field?.value.$el as HTMLInputElement) && valid;
+    if (schema === 'requiredSiteClassificationSchema') {
+        validateSiteClassificationFields(event.target as HTMLInputElement);
+    } else if (schema === 'requiredHeritageClassSchema') {
+        validateHeritageClassField(event.target as HTMLInputElement);
+    } else if (schema === 'requiredHeritageFunctionSchema') {
+        validateHeritageFunctionField(event.target as HTMLInputElement);
+    } else if (schema === 'requiredHeritageThemeSchema') {
+        validateHeritageThemeField(event.target as HTMLInputElement);
     }
-    return valid;
 };
 
 const updateAddHeritageClassCategory = function () {
     addContributingResourcesDisabled.value =
-        contributingResources.value.code < 0 ||
+        heritageClasses.value.length < 0 ||
         heritageSiteRef.value.siteClassification.heritageClasses.length > 4;
 };
 
 const updateAddOtherFunctionCategory = function () {
     addOtherFunctionCategoryDisabled.value =
-        functionCategory.value.name !== '' ||
+        heritageFunctions.value.length < 0 ||
         heritageSiteRef.value.siteClassification.heritageFunctions.length > 4;
 };
 
 const updateAddOtherHeritageSite = function () {
     addOtherHeritageSiteDisabled.value =
+        heritageThemes.value.length < 0 ||
         heritageSiteRef.value.siteClassification.heritageThemes.length > 4;
 };
 
-const valueUpdated = function (value: string | undefined) {
-    console.log(contributingResources.value.code);
-    console.log(functionCategory.value.code);
-
-    console.log(`valueUpdated: ${value}`);
-};
-
-const validateField = function (field: HTMLInputElement) {
+const validateSiteClassificationFields = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
     const key: keyof typeof HeritageSite =
         field.id as keyof typeof HeritageSite;
     const fieldValidation = requiredSiteClassificationSchema.shape[
         key
     ].safeParse(heritageSiteRef.value[key]);
+    if (fieldValidation.success) {
+        field.classList.remove('p-invalid');
+        errors.value[key] = [];
+    } else {
+        field.classList.add('p-invalid');
+        errors.value[key] = (
+            fieldValidation.error as typeof ZodError
+        ).flatten().formErrors;
+    }
+    return fieldValidation.success;
+};
+
+const validateHeritageClassField = function (field: HTMLInputElement) {
+    console.log(`ID: ${field.id}`);
+    const key: keyof typeof HeritageSite =
+        field.id as keyof typeof HeritageSite;
+    const fieldValidation = requiredHeritageClassSchema.shape[key].safeParse(
+        heritageSiteRef.value[key],
+    );
+    if (fieldValidation.success) {
+        field.classList.remove('p-invalid');
+        errors.value[key] = [];
+    } else {
+        field.classList.add('p-invalid');
+        errors.value[key] = (
+            fieldValidation.error as typeof ZodError
+        ).flatten().formErrors;
+    }
+    return fieldValidation.success;
+};
+
+const validateHeritageFunctionField = function (field: HTMLInputElement) {
+    console.log(`ID: ${field.id}`);
+    const key: keyof typeof HeritageSite =
+        field.id as keyof typeof HeritageSite;
+    const fieldValidation = requiredHeritageFunctionSchema.shape[key].safeParse(
+        heritageSiteRef.value[key],
+    );
+    if (fieldValidation.success) {
+        field.classList.remove('p-invalid');
+        errors.value[key] = [];
+    } else {
+        field.classList.add('p-invalid');
+        errors.value[key] = (
+            fieldValidation.error as typeof ZodError
+        ).flatten().formErrors;
+    }
+    return fieldValidation.success;
+};
+
+const validateHeritageThemeField = function (field: HTMLInputElement) {
+    console.log(`ID: ${field.id}`);
+    const key: keyof typeof HeritageSite =
+        field.id as keyof typeof HeritageSite;
+    const fieldValidation = requiredHeritageThemeSchema.shape[key].safeParse(
+        heritageSiteRef.value[key],
+    );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
         errors.value[key] = [];
@@ -159,12 +202,6 @@ const deleteHeritageThemeCallback = function (index: number) {
     updateAddOtherHeritageSite();
 };
 
-let validateFields = false;
-
-// This needs to be removed - added because ESLint was complaining. Need to figure out
-// configuration so API methods are not
-defineExpose({ isValid });
-
 onMounted(() => {
     heritageSiteRef.value.siteClassification.heritageClasses = heritageClasses;
     heritageSiteRef.value.siteClassification.heritageFunctions =
@@ -188,21 +225,20 @@ onMounted(() => {
             :required="true"
         >
             <div>
-                <Dropdown
+                <InputText
                     id="contributingResources"
                     ref="numberOfResourcesField"
                     v-model="contributingResources"
-                    placeholder="0"
-                    optionLabel="name"
-                    :options="contributingResourcesOptions"
-                    aria-describedby="reference-number-help"
+                    aria-describedby="contributing-resources-help"
                     aria-required="true"
                     fluid
-                    class="w-full md:w-14rem"
-                    @update:model-value="valueUpdated"
+                    class="inline-block"
+                    @change="
+                        valueChanged($event, 'requiredHeritageClassSchema')
+                    "
                 />
                 <Button
-                    id="saveHeritageClasss"
+                    id="saveHeritageClass"
                     :disabled="addContributingResourcesDisabled"
                     :aria-disabled="addContributingResourcesDisabled"
                     label="Add"
@@ -215,46 +251,61 @@ onMounted(() => {
             <p class="mb-1">Heritage Category</p>
             <div class="card flex flex-wrap gap-4">
                 <div class="flex items-center gap-2">
-                    <Checkbox
+                    <RadioButton
                         v-model="heritageCategory"
-                        inputId="archeological_site"
+                        inputId="heritageCategory"
                         value="Archeological Site"
+                        @change="
+                            valueChanged($event, 'requiredHeritageClassSchema')
+                        "
                     />
                     <label for="archeological_site">
                         Archaeological Site / Remains
                     </label>
                 </div>
                 <div class="flex items-center gap-2">
-                    <Checkbox
+                    <RadioButton
                         v-model="heritageCategory"
-                        inputId="building"
+                        inputId="heritageCategory"
                         value="Building"
+                        @change="
+                            valueChanged($event, 'requiredHeritageClassSchema')
+                        "
                     />
                     <label for="building"> Building </label>
                 </div>
                 <div class="flex items-center gap-2">
-                    <Checkbox
+                    <RadioButton
                         v-model="heritageCategory"
-                        inputId="collection"
+                        inputId="heritageCategory"
                         value="Collection"
+                        @change="
+                            valueChanged($event, 'requiredHeritageClassSchema')
+                        "
                     />
                     <label for="collection"> Collection </label>
                 </div>
                 <div class="flex items-center gap-2">
-                    <Checkbox
+                    <RadioButton
                         v-model="heritageCategory"
-                        inputId="landscape_features"
+                        inputId="heritageCategory"
                         value="Landscape Features"
+                        @change="
+                            valueChanged($event, 'requiredHeritageClassSchema')
+                        "
                     />
                     <label for="landscape_features">
                         Landscape(s) or Landscape Feature(s)
                     </label>
                 </div>
                 <div class="flex items-center gap-2">
-                    <Checkbox
+                    <RadioButton
                         v-model="heritageCategory"
-                        inputId="structure"
+                        inputId="heritageCategory"
                         value="Structure"
+                        @change="
+                            valueChanged($event, 'requiredHeritageClassSchema')
+                        "
                     />
                     <label for="structure"> Structure </label>
                 </div>
@@ -262,42 +313,57 @@ onMounted(() => {
             <p class="mb-1">Ownership</p>
             <div class="card flex flex-wrap gap-4">
                 <div class="flex items-center gap-2">
-                    <Checkbox
+                    <RadioButton
                         v-model="ownership"
-                        inputId="not_for_profit"
+                        inputId="ownership"
                         value="Not-for-profit"
+                        @change="
+                            valueChanged($event, 'requiredHeritageClassSchema')
+                        "
                     />
                     <label for="not_for_profit"> Not-for-profit </label>
                 </div>
                 <div class="flex items-center gap-2">
-                    <Checkbox
+                    <RadioButton
                         v-model="ownership"
-                        inputId="private"
+                        inputId="ownership"
                         value="Private"
+                        @change="
+                            valueChanged($event, 'requiredHeritageClassSchema')
+                        "
                     />
                     <label for="private"> Private </label>
                 </div>
                 <div class="flex items-center gap-2">
-                    <Checkbox
+                    <RadioButton
                         v-model="ownership"
-                        inputId="public_federal"
+                        inputId="ownership"
                         value="Public (federal)"
+                        @change="
+                            valueChanged($event, 'requiredHeritageClassSchema')
+                        "
                     />
                     <label for="public_federal"> Public (federal) </label>
                 </div>
                 <div class="flex items-center gap-2">
-                    <Checkbox
+                    <RadioButton
                         v-model="ownership"
-                        inputId="public_local"
+                        inputId="ownership"
                         value="Public (local)"
+                        @change="
+                            valueChanged($event, 'requiredHeritageClassSchema')
+                        "
                     />
                     <label for="public_local"> Public (local) </label>
                 </div>
                 <div class="flex items-center gap-2">
-                    <Checkbox
+                    <RadioButton
                         v-model="ownership"
-                        inputId="ownership5"
+                        inputId="ownership"
                         value="Public (provincial)"
+                        @change="
+                            valueChanged($event, 'requiredHeritageClassSchema')
+                        "
                     />
                     <label for="public_provincial"> Public (provincial) </label>
                 </div>
@@ -307,7 +373,7 @@ onMounted(() => {
             v-slot="slotProps"
             :showDeleteButton="true"
             :displayValues="heritageClasses"
-            label="Contributing Resource(s)"
+            label="Heritage Class/Classes"
             :deleteCallback="deleteContributingResourcesCallback"
         >
             <div
@@ -316,7 +382,7 @@ onMounted(() => {
                 class="parent value"
             >
                 {{ slot.heritageCategory }} {{ slot.ownership }}
-                {{ slot.contributingResources?.name }}
+                {{ slot.contributingResources }}
             </div>
         </MultiValuePlaceholder>
     </FieldSet>
@@ -336,6 +402,8 @@ onMounted(() => {
                     id="functionCategory"
                     ref="functionCategoryField"
                     v-model="functionCategory"
+                    optionValue="code"
+                    inputId="functionCategory"
                     optionLabel="name"
                     placeholder="Select Function Category"
                     :options="functionCategoryOptions"
@@ -343,22 +411,36 @@ onMounted(() => {
                     aria-required="true"
                     fluid
                     class="w-full md:w-14rem"
-                    @update:model-value="valueUpdated"
+                    @update:model-value="
+                        valueChanged($event, 'requiredHeritageFunctionSchema')
+                    "
                 />
                 <div class="inline-block">
                     <div class="inline-block">
                         <Checkbox
                             v-model="functionCategoryType"
-                            inputId="current"
+                            inputId="functionCategoryType"
                             value="Current"
+                            @change="
+                                valueChanged(
+                                    $event,
+                                    'requiredHeritageFunctionSchema',
+                                )
+                            "
                         />
                         <label for="current">Current</label>
                     </div>
                     <div class="inline-block">
                         <Checkbox
                             v-model="functionCategoryType"
-                            inputId="historic"
+                            inputId="functionCategoryType"
                             value="Historic"
+                            @change="
+                                valueChanged(
+                                    $event,
+                                    'requiredHeritageFunctionSchema',
+                                )
+                            "
                         />
                         <label for="historic">Historic</label>
                     </div>
@@ -407,13 +489,17 @@ onMounted(() => {
                     ref="heritageThemeField"
                     v-model="heritageTheme"
                     optionLabel="name"
+                    optionValue="code"
+                    inputId="heritageTheme"
                     placeholder="Select Function Theme"
                     :options="functionThemeOptions"
                     aria-describedby="function-theme-help"
                     aria-required="true"
                     fluid
                     class="w-full md:w-14rem"
-                    @update:model-value="valueUpdated"
+                    @update:model-value="
+                        valueChanged($event, 'requiredHeritageThemeSchema')
+                    "
                 />
             </div>
             <Button

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -11,6 +11,10 @@ import LabelledInput from '@/bcgov_arches_common/components/labelledinput/Labell
 import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePlaceholder/MultiValuePlaceholder.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
 import {
+    SiteClassification,
+    HeritageClass,
+    HeritageFunction,
+    HeritageTheme,
     requiredSiteClassificationSchema,
     requiredHeritageClassSchema,
     requiredHeritageFunctionSchema,
@@ -62,26 +66,26 @@ const valueChanged = function (event: Event, schema: string) {
 
 const updateAddHeritageClassCategory = function () {
     addContributingResourcesDisabled.value =
-        heritageClasses.value.length < 0 ||
+        heritageClasses.value.length < 1 ||
         heritageSiteRef.value.siteClassification.heritageClasses.length > 4;
 };
 
 const updateAddOtherFunctionCategory = function () {
     addOtherFunctionCategoryDisabled.value =
-        heritageFunctions.value.length < 0 ||
+        heritageFunctions.value.length < 1 ||
         heritageSiteRef.value.siteClassification.heritageFunctions.length > 4;
 };
 
 const updateAddOtherHeritageSite = function () {
     addOtherHeritageSiteDisabled.value =
-        heritageThemes.value.length < 0 ||
+        heritageThemes.value.length < 1 ||
         heritageSiteRef.value.siteClassification.heritageThemes.length > 4;
 };
 
 const validateSiteClassificationFields = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
-    const key: keyof typeof HeritageSite =
-        field.id as keyof typeof HeritageSite;
+    const key: keyof typeof SiteClassification =
+        field.id as keyof typeof SiteClassification;
     const fieldValidation = requiredSiteClassificationSchema.shape[
         key
     ].safeParse(heritageSiteRef.value[key]);
@@ -99,10 +103,10 @@ const validateSiteClassificationFields = function (field: HTMLInputElement) {
 
 const validateHeritageClassField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
-    const key: keyof typeof HeritageSite =
-        field.id as keyof typeof HeritageSite;
+    const key: keyof typeof HeritageClass =
+        field.id as keyof typeof HeritageClass;
     const fieldValidation = requiredHeritageClassSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.heritageClasses[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -118,10 +122,10 @@ const validateHeritageClassField = function (field: HTMLInputElement) {
 
 const validateHeritageFunctionField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
-    const key: keyof typeof HeritageSite =
-        field.id as keyof typeof HeritageSite;
+    const key: keyof typeof HeritageFunction =
+        field.id as keyof typeof HeritageFunction;
     const fieldValidation = requiredHeritageFunctionSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.heritageFunctions[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -137,10 +141,10 @@ const validateHeritageFunctionField = function (field: HTMLInputElement) {
 
 const validateHeritageThemeField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
-    const key: keyof typeof HeritageSite =
-        field.id as keyof typeof HeritageSite;
+    const key: keyof typeof HeritageTheme =
+        field.id as keyof typeof HeritageTheme;
     const fieldValidation = requiredHeritageThemeSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.heritageThemes[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -402,7 +406,6 @@ onMounted(() => {
                     id="functionCategory"
                     ref="functionCategoryField"
                     v-model="functionCategory"
-                    optionValue="code"
                     inputId="functionCategory"
                     optionLabel="name"
                     placeholder="Select Function Category"
@@ -489,7 +492,6 @@ onMounted(() => {
                     ref="heritageThemeField"
                     v-model="heritageTheme"
                     optionLabel="name"
-                    optionValue="code"
                     inputId="heritageTheme"
                     placeholder="Select Function Theme"
                     :options="functionThemeOptions"

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -106,7 +106,7 @@ const validateHeritageClassField = function (field: HTMLInputElement) {
     const key: keyof typeof HeritageClass =
         field.id as keyof typeof HeritageClass;
     const fieldValidation = requiredHeritageClassSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.siteClassification[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -125,7 +125,7 @@ const validateHeritageFunctionField = function (field: HTMLInputElement) {
     const key: keyof typeof HeritageFunction =
         field.id as keyof typeof HeritageFunction;
     const fieldValidation = requiredHeritageFunctionSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.siteClassification[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -144,7 +144,7 @@ const validateHeritageThemeField = function (field: HTMLInputElement) {
     const key: keyof typeof HeritageTheme =
         field.id as keyof typeof HeritageTheme;
     const fieldValidation = requiredHeritageThemeSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.siteClassification[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -9,7 +9,7 @@ import Dropdown from 'primevue/dropdown';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePlaceholder/MultiValuePlaceholder.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
-import { requiredHeritageSiteSchema } from '@/bcrhp/schema/HeritageSiteSchema.ts';
+import { requiredSiteClassificationSchema } from '@/bcrhp/schema/SiteClassificationSchema.ts';
 import type { ZodError } from 'zod';
 
 const heritageSite: typeof HeritageSite = inject(
@@ -35,9 +35,9 @@ const functionThemeOptions = ref([
     { name: 'Architecture and Design', code: 'architecture_and_design' },
 ]);
 const contributingResources = ref({ name: '', code: 0 });
-const totalContributingResources = ref([] as Array<string>);
+const heritageClasses = ref([] as Array<string>);
 const functionCategory = ref({ name: '', code: '' });
-const functionCategories = ref([] as Array<string>);
+const heritageFunctions = ref([] as Array<string>);
 const heritageTheme = ref({ name: '', code: '' });
 const heritageThemes = ref([] as Array<string>);
 const addContributingResourcesDisabled = ref(false);
@@ -52,8 +52,7 @@ const fields = {
 };
 const heritageCategory = ref();
 const ownership = ref();
-const functionCategoryCurrent = ref();
-const functionCategoryHistoric = ref();
+const functionCategoryType = ref();
 
 const isValid = () => {
     // We don't want to validate fields the first time we show the step
@@ -69,21 +68,21 @@ const isValid = () => {
     return valid;
 };
 
-const updateAddContributingResourceCategory = function () {
+const updateAddHeritageClassCategory = function () {
     addContributingResourcesDisabled.value =
-        contributingResources.value.code < 1 ||
-        heritageSiteRef.value.totalContributingResources.length > 4;
+        contributingResources.value.code < 0 ||
+        heritageSiteRef.value.siteClassification.heritageClasses.length > 4;
 };
 
 const updateAddOtherFunctionCategory = function () {
     addOtherFunctionCategoryDisabled.value =
         functionCategory.value.name !== '' ||
-        heritageSiteRef.value.functionCategories.length > 4;
+        heritageSiteRef.value.siteClassification.heritageFunctions.length > 4;
 };
 
 const updateAddOtherHeritageSite = function () {
     addOtherHeritageSiteDisabled.value =
-        heritageSiteRef.value.heritageThemes.length > 4;
+        heritageSiteRef.value.siteClassification.heritageThemes.length > 4;
 };
 
 const valueUpdated = function (value: string | undefined) {
@@ -97,9 +96,9 @@ const validateField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
     const key: keyof typeof HeritageSite =
         field.id as keyof typeof HeritageSite;
-    const fieldValidation = requiredHeritageSiteSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
-    );
+    const fieldValidation = requiredSiteClassificationSchema.shape[
+        key
+    ].safeParse(heritageSiteRef.value[key]);
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
         errors.value[key] = [];
@@ -112,43 +111,50 @@ const validateField = function (field: HTMLInputElement) {
     return fieldValidation.success;
 };
 
-const saveContributingResource = function () {
-    console.log('saveContributingResource');
-    heritageSiteRef.value.totalContributingResources.push(
-        contributingResources.value,
-    );
+const saveHeritageClass = function () {
+    console.log('saveHeritageClass');
+    heritageSiteRef.value.siteClassification.heritageClasses.push({
+        contributingResources: contributingResources.value,
+        heritageCategory: heritageCategory.value?.toString(),
+        ownership: ownership.value?.toString(),
+    });
 
-    updateAddContributingResourceCategory();
+    updateAddHeritageClassCategory();
 };
 
 const saveFunctionCategory = function () {
     console.log('saveFunctionCategory');
-    heritageSiteRef.value.functionCategories.push(functionCategory.value);
+    heritageSiteRef.value.siteClassification.heritageFunctions.push({
+        functionCategory: functionCategory.value,
+        functionCategoryType: functionCategoryType.value?.toString(),
+    });
 
     updateAddOtherFunctionCategory();
 };
 
 const saveHeritageTheme = function () {
     console.log('saveHeritageThemes');
-    heritageSiteRef.value.heritageThemes.push(heritageTheme.value);
+    heritageSiteRef.value.siteClassification.heritageThemes.push(
+        heritageTheme.value,
+    );
 
     updateAddOtherHeritageSite();
 };
 
 const deleteContributingResourcesCallback = function (index: number) {
-    heritageSiteRef.value.totalContributingResources.splice(index, 1);
+    heritageSiteRef.value.siteClassification.heritageClasses.splice(index, 1);
 
-    updateAddContributingResourceCategory();
+    updateAddHeritageClassCategory();
 };
 
 const deleteFunctionCategoryCallback = function (index: number) {
-    heritageSiteRef.value.functionCategories.splice(index, 1);
+    heritageSiteRef.value.siteClassification.heritageFunctions.splice(index, 1);
 
     updateAddOtherFunctionCategory();
 };
 
 const deleteHeritageThemeCallback = function (index: number) {
-    heritageSiteRef.value.heritageThemes.splice(index, 1);
+    heritageSiteRef.value.siteClassification.heritageThemes.splice(index, 1);
 
     updateAddOtherHeritageSite();
 };
@@ -160,12 +166,12 @@ let validateFields = false;
 defineExpose({ isValid });
 
 onMounted(() => {
-    heritageSiteRef.value.totalContributingResources =
-        totalContributingResources;
-    heritageSiteRef.value.functionCategories = functionCategories;
-    heritageSiteRef.value.heritageThemes = heritageThemes;
+    heritageSiteRef.value.siteClassification.heritageClasses = heritageClasses;
+    heritageSiteRef.value.siteClassification.heritageFunctions =
+        heritageFunctions;
+    heritageSiteRef.value.siteClassification.heritageThemes = heritageThemes;
 
-    updateAddContributingResourceCategory();
+    updateAddHeritageClassCategory();
     updateAddOtherFunctionCategory();
     updateAddOtherHeritageSite();
 });
@@ -196,12 +202,12 @@ onMounted(() => {
                     @update:model-value="valueUpdated"
                 />
                 <Button
-                    id="saveContributingResources"
+                    id="saveHeritageClasss"
                     :disabled="addContributingResourcesDisabled"
                     :aria-disabled="addContributingResourcesDisabled"
                     label="Add"
                     class="inline-block"
-                    @click="saveContributingResource"
+                    @click="saveHeritageClass"
                 ></Button>
             </div>
         </LabelledInput>
@@ -211,51 +217,46 @@ onMounted(() => {
                 <div class="flex items-center gap-2">
                     <Checkbox
                         v-model="heritageCategory"
-                        inputId="category1"
-                        name="archaeologicalSite"
-                        value="archaeologicalSite"
+                        inputId="archeological_site"
+                        value="Archeological Site"
                     />
-                    <label for="category1">
+                    <label for="archeological_site">
                         Archaeological Site / Remains
                     </label>
                 </div>
                 <div class="flex items-center gap-2">
                     <Checkbox
                         v-model="heritageCategory"
-                        inputId="category2"
-                        name="building"
-                        value="building"
+                        inputId="building"
+                        value="Building"
                     />
-                    <label for="category2"> Building </label>
+                    <label for="building"> Building </label>
                 </div>
                 <div class="flex items-center gap-2">
                     <Checkbox
                         v-model="heritageCategory"
-                        inputId="category3"
-                        name="collection"
-                        value="collection"
+                        inputId="collection"
+                        value="Collection"
                     />
-                    <label for="category3"> Collection </label>
+                    <label for="collection"> Collection </label>
                 </div>
                 <div class="flex items-center gap-2">
                     <Checkbox
                         v-model="heritageCategory"
-                        inputId="category4"
-                        name="landscapeFeatures"
-                        value="landscapeFeatures"
+                        inputId="landscape_features"
+                        value="Landscape Features"
                     />
-                    <label for="category4">
+                    <label for="landscape_features">
                         Landscape(s) or Landscape Feature(s)
                     </label>
                 </div>
                 <div class="flex items-center gap-2">
                     <Checkbox
                         v-model="heritageCategory"
-                        inputId="category5"
-                        name="structure"
-                        value="structure"
+                        inputId="structure"
+                        value="Structure"
                     />
-                    <label for="category5"> Structure </label>
+                    <label for="structure"> Structure </label>
                 </div>
             </div>
             <p class="mb-1">Ownership</p>
@@ -263,58 +264,60 @@ onMounted(() => {
                 <div class="flex items-center gap-2">
                     <Checkbox
                         v-model="ownership"
-                        inputId="ownership1"
-                        name="Not-for-profit"
-                        value="notForProfit"
+                        inputId="not_for_profit"
+                        value="Not-for-profit"
                     />
-                    <label for="ownership1"> Not-for-profit </label>
+                    <label for="not_for_profit"> Not-for-profit </label>
                 </div>
                 <div class="flex items-center gap-2">
                     <Checkbox
                         v-model="ownership"
-                        inputId="ownership2"
-                        name="private"
-                        value="private"
+                        inputId="private"
+                        value="Private"
                     />
-                    <label for="ownership2"> Private </label>
+                    <label for="private"> Private </label>
                 </div>
                 <div class="flex items-center gap-2">
                     <Checkbox
                         v-model="ownership"
-                        inputId="ownership3"
-                        name="publicFederal"
-                        value="publicFederal"
+                        inputId="public_federal"
+                        value="Public (federal)"
                     />
-                    <label for="ownership3"> Public (federal) </label>
+                    <label for="public_federal"> Public (federal) </label>
                 </div>
                 <div class="flex items-center gap-2">
                     <Checkbox
                         v-model="ownership"
-                        inputId="ownership4"
-                        name="publicLocal"
-                        value="publicLocal"
+                        inputId="public_local"
+                        value="Public (local)"
                     />
-                    <label for="ownership4"> Public (local) </label>
+                    <label for="public_local"> Public (local) </label>
                 </div>
                 <div class="flex items-center gap-2">
                     <Checkbox
                         v-model="ownership"
                         inputId="ownership5"
-                        name="publicProvincial"
-                        value="publicProvincial"
+                        value="Public (provincial)"
                     />
-                    <label for="category5"> Public (provincial) </label>
+                    <label for="public_provincial"> Public (provincial) </label>
                 </div>
             </div>
         </div>
         <MultiValuePlaceholder
             v-slot="slotProps"
             :showDeleteButton="true"
-            :displayValues="totalContributingResources"
+            :displayValues="heritageClasses"
             label="Contributing Resource(s)"
             :deleteCallback="deleteContributingResourcesCallback"
         >
-            <div class="parent value">{{ slotProps.value.name }}</div>
+            <div
+                v-for="slot in slotProps"
+                :key="slot"
+                class="parent value"
+            >
+                {{ slot.heritageCategory }} {{ slot.ownership }}
+                {{ slot.contributingResources?.name }}
+            </div>
         </MultiValuePlaceholder>
     </FieldSet>
     <Fieldset
@@ -345,26 +348,24 @@ onMounted(() => {
                 <div class="inline-block">
                     <div class="inline-block">
                         <Checkbox
-                            v-model="functionCategoryCurrent"
+                            v-model="functionCategoryType"
                             inputId="current"
-                            name="functionCategoryCurrent"
-                            value="functionCategoryCurrent"
+                            value="Current"
                         />
                         <label for="current">Current</label>
                     </div>
                     <div class="inline-block">
                         <Checkbox
-                            v-model="functionCategoryHistoric"
+                            v-model="functionCategoryType"
                             inputId="historic"
-                            name="functionCategoryCHistoric"
-                            value="functionCategoryCHistoric"
+                            value="Historic"
                         />
                         <label for="historic">Historic</label>
                     </div>
                 </div>
             </div>
             <Button
-                id="addOtherName"
+                id="saveFunctionCategory"
                 label="Add"
                 class="inline-block"
                 :disabled="addOtherFunctionCategoryDisabled"
@@ -375,11 +376,18 @@ onMounted(() => {
         <MultiValuePlaceholder
             v-slot="slotProps"
             :showDeleteButton="true"
-            :displayValues="functionCategories"
+            :displayValues="heritageFunctions"
             label="Category/Categories"
             :deleteCallback="deleteFunctionCategoryCallback"
         >
-            <div class="parent value">{{ slotProps.value.name }}</div>
+            <div
+                v-for="slot in slotProps"
+                :key="slot"
+                class="parent value"
+            >
+                {{ slot.functionCategory?.name }}
+                {{ slot.functionCategoryType }}
+            </div>
         </MultiValuePlaceholder>
     </Fieldset>
     <Fieldset
@@ -424,7 +432,7 @@ onMounted(() => {
             label="Theme(s)"
             :deleteCallback="deleteHeritageThemeCallback"
         >
-            <div class="parent value">{{ slotProps.value.name }}</div>
+            <div class="parent value">{{ slotProps.value?.name }}</div>
         </MultiValuePlaceholder>
     </Fieldset>
 </template>

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -106,7 +106,7 @@ const validateHeritageClassField = function (field: HTMLInputElement) {
     const key: keyof typeof HeritageClass =
         field.id as keyof typeof HeritageClass;
     const fieldValidation = requiredHeritageClassSchema.shape[key].safeParse(
-        heritageSiteRef.value.heritageClasses[key],
+        heritageSiteRef.value[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -125,7 +125,7 @@ const validateHeritageFunctionField = function (field: HTMLInputElement) {
     const key: keyof typeof HeritageFunction =
         field.id as keyof typeof HeritageFunction;
     const fieldValidation = requiredHeritageFunctionSchema.shape[key].safeParse(
-        heritageSiteRef.value.heritageFunctions[key],
+        heritageSiteRef.value[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -144,7 +144,7 @@ const validateHeritageThemeField = function (field: HTMLInputElement) {
     const key: keyof typeof HeritageTheme =
         field.id as keyof typeof HeritageTheme;
     const fieldValidation = requiredHeritageThemeSchema.shape[key].safeParse(
-        heritageSiteRef.value.heritageThemes[key],
+        heritageSiteRef.value[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -414,7 +414,7 @@ onMounted(() => {
                     aria-required="true"
                     fluid
                     class="w-full md:w-14rem"
-                    @update:model-value="
+                    @blur="
                         valueChanged($event, 'requiredHeritageFunctionSchema')
                     "
                 />
@@ -499,9 +499,7 @@ onMounted(() => {
                     aria-required="true"
                     fluid
                     class="w-full md:w-14rem"
-                    @update:model-value="
-                        valueChanged($event, 'requiredHeritageThemeSchema')
-                    "
+                    @blur="valueChanged($event, 'requiredHeritageThemeSchema')"
                 />
             </div>
             <Button

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -1,18 +1,23 @@
 <script setup lang="ts">
-import { useTemplateRef, inject, ref, onMounted } from 'vue';
+import { inject, ref, onMounted } from 'vue';
 import type { Ref } from 'vue';
 
 import FieldSet from 'primevue/fieldset';
 import InputText from 'primevue/inputtext';
 import Button from 'primevue/button';
-import Checkbox from 'primevue/checkbox';
+import RadioButton from 'primevue/radiobutton';
 import DatePicker from 'primevue/datepicker';
 import Dropdown from 'primevue/dropdown';
 
 import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePlaceholder/MultiValuePlaceholder.vue';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
-import { requiredSiteDetailsSchema } from '@/bcrhp/schema/SiteDetailsSchema.ts';
+import {
+    requiredSiteDetailsSchema,
+    requiredChronologySchema,
+    requiredArchitectBuilderSchema,
+    requiredRequiredURLsSchema,
+} from '@/bcrhp/schema/SiteDetailsSchema.ts';
 import type { ZodError } from 'zod';
 
 const heritageSite: typeof HeritageSite = inject(
@@ -39,65 +44,88 @@ const urlTypeOptions = ref([
     { name: 'Historic Place Website', code: 'historic_place_website' },
     { name: 'Provincial Website', code: 'provincial_website' },
 ]);
+const eventType = ref();
+const circa = ref('Exact');
 const addURLDisabled = ref(false);
 
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
 
-// These names need to match the Zog schema
-const eventType = ref();
-const circa = ref('Exact');
+const valueChanged = function (event: Event, schema: string) {
+    console.log(event);
 
-const fields = {
-    startYearField: useTemplateRef('startYearField'),
-    endYearField: useTemplateRef('endYearField'),
-    chronologyNotesField: useTemplateRef('chronologyNotesField'),
-    architectOrBuilderNameField: useTemplateRef('architectOrBuilderNameField'),
-    architectOrBuilderTypeField: useTemplateRef('architectOrBuilderTypeField'),
-    urlTypeField: useTemplateRef('urlTypeField'),
-    linkTextField: useTemplateRef('linkTextField'),
-    urlField: useTemplateRef('urlField'),
-};
-
-const isValid = () => {
-    // We don't want to validate fields the first time we show the step
-    if (!validateFields) {
-        validateFields = true;
-        return true;
+    if (schema === 'requiredSiteDetailsSchema') {
+        validateSiteDetailsFields(event.target as HTMLInputElement);
+    } else if (schema === 'requiredChronologySchema') {
+        validateChronologyField(event.target as HTMLInputElement);
+    } else if (schema === 'requiredArchitectBuilderSchema') {
+        validateArchitectOrBuilderField(event.target as HTMLInputElement);
+    } else if (schema === 'requiredRequiredURLsSchema') {
+        validateURLField(event.target as HTMLInputElement);
     }
-    let valid = true;
-
-    for (const field of Object.values(fields) as Array<Ref>) {
-        valid = validateField(field?.value.$el as HTMLInputElement) && valid;
-    }
-    return valid;
 };
-
-const valueUpdated = function (value: string | undefined) {
-    console.log(`valueUpdated: ${value}`);
-};
-
-const valueChanged = function (event: Event) {
-    console.log(`valueChanged`);
-    validateField(event.target as HTMLInputElement);
-};
-
-const onFocusHandler = function (event: Event) {
-    console.log(`onFocusHandler ${event}`);
-    // (event.target as HTMLInputElement).classList.remove("p-invalid");
-};
-
-const onFocusOutHandler = function (event: Event) {
-    console.log(`onFocusOutHandler`);
-    validateField(event.target as HTMLInputElement);
-    // (event.target as HTMLInputElement).classList.remove("p-invalid");
-};
-
-const validateField = function (field: HTMLInputElement) {
+const validateSiteDetailsFields = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
     const key: keyof typeof HeritageSite =
         field.id as keyof typeof HeritageSite;
     const fieldValidation = requiredSiteDetailsSchema.shape[key].safeParse(
+        heritageSiteRef.value[key],
+    );
+    if (fieldValidation.success) {
+        field.classList.remove('p-invalid');
+        errors.value[key] = [];
+    } else {
+        field.classList.add('p-invalid');
+        errors.value[key] = (
+            fieldValidation.error as typeof ZodError
+        ).flatten().formErrors;
+    }
+    return fieldValidation.success;
+};
+
+const validateChronologyField = function (field: HTMLInputElement) {
+    console.log(`ID: ${field.id}`);
+    const key: keyof typeof HeritageSite =
+        field.id as keyof typeof HeritageSite;
+    const fieldValidation = requiredChronologySchema.shape[key].safeParse(
+        heritageSiteRef.value[key],
+    );
+    if (fieldValidation.success) {
+        field.classList.remove('p-invalid');
+        errors.value[key] = [];
+    } else {
+        field.classList.add('p-invalid');
+        errors.value[key] = (
+            fieldValidation.error as typeof ZodError
+        ).flatten().formErrors;
+    }
+    return fieldValidation.success;
+};
+
+const validateArchitectOrBuilderField = function (field: HTMLInputElement) {
+    console.log(`ID: ${field.id}`);
+    const key: keyof typeof HeritageSite =
+        field.id as keyof typeof HeritageSite;
+    const fieldValidation = requiredArchitectBuilderSchema.shape[key].safeParse(
+        heritageSiteRef.value[key],
+    );
+    if (fieldValidation.success) {
+        field.classList.remove('p-invalid');
+        errors.value[key] = [];
+    } else {
+        field.classList.add('p-invalid');
+        errors.value[key] = (
+            fieldValidation.error as typeof ZodError
+        ).flatten().formErrors;
+    }
+    return fieldValidation.success;
+};
+
+const validateURLField = function (field: HTMLInputElement) {
+    console.log(`ID: ${field.id}`);
+    const key: keyof typeof HeritageSite =
+        field.id as keyof typeof HeritageSite;
+    const fieldValidation = requiredRequiredURLsSchema.shape[key].safeParse(
         heritageSiteRef.value[key],
     );
     if (fieldValidation.success) {
@@ -181,12 +209,6 @@ const deleteURLCallback = function (index: number) {
     updateAddOtherURL();
 };
 
-let validateFields = false;
-
-// This needs to be removed - added because ESLint was complaining. Need to figure out
-// configuration so API methods are not
-defineExpose({ isValid });
-
 onMounted(() => {
     heritageSiteRef.value.siteDetails.chronologies = chronologies;
     heritageSiteRef.value.siteDetails.architectsOrBuilders =
@@ -209,18 +231,30 @@ onMounted(() => {
                     <p class="mb-1">Event Type</p>
                     <div class="card flex flex-col">
                         <div class="flex items-center gap-2">
-                            <Checkbox
+                            <RadioButton
                                 v-model="eventType"
-                                inputId="construction"
+                                inputId="eventType"
                                 value="Construction"
+                                @change="
+                                    valueChanged(
+                                        $event,
+                                        'requiredChronologySchema',
+                                    )
+                                "
                             />
                             <label for="construction"> Construction </label>
                         </div>
                         <div class="flex items-center gap-2">
-                            <Checkbox
+                            <RadioButton
                                 v-model="eventType"
-                                inputId="significant"
+                                inputId="eventType"
                                 value="Significant"
+                                @change="
+                                    valueChanged(
+                                        $event,
+                                        'requiredChronologySchema',
+                                    )
+                                "
                             />
                             <label for="significant"> Significant </label>
                         </div>
@@ -236,6 +270,9 @@ onMounted(() => {
                 view="year"
                 aria-describedby="start-year-help"
                 aria-required="true"
+                @update:model-value="
+                    valueChanged($event, 'requiredChronologySchema')
+                "
             />
             <p>End Year</p>
             <DatePicker
@@ -246,12 +283,16 @@ onMounted(() => {
                 view="year"
                 aria-describedby="end-year-help"
                 aria-required="true"
+                @update:model-value="
+                    valueChanged($event, 'requiredChronologySchema')
+                "
             />
             <div class="inline-block">
                 <Checkbox
                     v-model="circa"
                     inputId="circa"
                     value="Circa"
+                    @change="valueChanged($event, 'requiredChronologySchema')"
                 />
                 <label for="circa"> Circa </label>
             </div>
@@ -273,9 +314,9 @@ onMounted(() => {
                         fluid
                         class="inline-block"
                         @editorChange="valueChanged"
-                        @focus="onFocusHandler"
-                        @blur="onFocusOutHandler"
-                        @update:model-value="valueUpdated"
+                        @change="
+                            valueChanged($event, 'requiredChronologySchema')
+                        "
                     />
                     <Button
                         id="saveChronology"
@@ -325,10 +366,12 @@ onMounted(() => {
                         aria-describedby="architect-or-builder-help"
                         aria-required="true"
                         fluid
-                        @change="valueChanged"
-                        @focus="onFocusHandler"
-                        @focusout="onFocusOutHandler"
-                        @update:model-value="valueUpdated"
+                        @change="
+                            valueChanged(
+                                $event,
+                                'requiredArchitectBuilderSchema',
+                            )
+                        "
                     />
                 </div>
             </LabelledInput>
@@ -343,13 +386,16 @@ onMounted(() => {
                     ref="architectOrBuilderTypeField"
                     v-model="architectOrBuilderType"
                     optionLabel="name"
+                    optionValue="code"
                     placeholder="Select Type"
                     :options="architectOrBuilderTypeOptions"
                     aria-describedby="architect-or-builder-type-help"
                     aria-required="true"
                     fluid
                     class="w-full md:w-14rem"
-                    @update:model-value="valueUpdated"
+                    @update:model-value="
+                        valueChanged($event, 'requiredArchitectBuilderSchema')
+                    "
                 />
             </LabelledInput>
         </div>
@@ -370,10 +416,12 @@ onMounted(() => {
                         aria-required="true"
                         fluid
                         class="inline-block"
-                        @change="valueChanged"
-                        @focus="onFocusHandler"
-                        @focusout="onFocusOutHandler"
-                        @update:model-value="valueUpdated"
+                        @change="
+                            valueChanged(
+                                $event,
+                                'requiredArchitectBuilderSchema',
+                            )
+                        "
                     />
                     <Button
                         id="addOtherName"
@@ -421,12 +469,15 @@ onMounted(() => {
                     v-model="urlType"
                     placeholder="Select Type"
                     optionLabel="name"
+                    optionValue="code"
                     :options="urlTypeOptions"
                     aria-describedby="url-type-help"
                     aria-required="true"
                     fluid
                     class="w-full md:w-14rem"
-                    @update:model-value="valueUpdated"
+                    @update:model-value="
+                        valueChanged($event, 'requiredRequiredURLsSchema')
+                    "
                 />
             </LabelledInput>
             <LabelledInput
@@ -444,10 +495,9 @@ onMounted(() => {
                         aria-describedby="link-text-help"
                         aria-required="true"
                         fluid
-                        @change="valueChanged"
-                        @focus="onFocusHandler"
-                        @focusout="onFocusOutHandler"
-                        @update:model-value="valueUpdated"
+                        @change="
+                            valueChanged($event, 'requiredRequiredURLsSchema')
+                        "
                     />
                 </div>
             </LabelledInput>
@@ -469,10 +519,9 @@ onMounted(() => {
                         aria-required="true"
                         fluid
                         class="inline-block"
-                        @change="valueChanged"
-                        @focus="onFocusHandler"
-                        @focusout="onFocusOutHandler"
-                        @update:model-value="valueUpdated"
+                        @change="
+                            valueChanged($event, 'requiredRequiredURLsSchema')
+                        "
                     />
                     <Button
                         id="saveURL"

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -90,7 +90,7 @@ const validateChronologyField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
     const key: keyof typeof Chronology = field.id as keyof typeof Chronology;
     const fieldValidation = requiredChronologySchema.shape[key].safeParse(
-        heritageSiteRef.value.chronologies[key],
+        heritageSiteRef.value[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -109,7 +109,7 @@ const validateArchitectOrBuilderField = function (field: HTMLInputElement) {
     const key: keyof typeof ArchitectOrBuilder =
         field.id as keyof typeof ArchitectOrBuilder;
     const fieldValidation = requiredArchitectBuilderSchema.shape[key].safeParse(
-        heritageSiteRef.value.architectsOrBuilders[key],
+        heritageSiteRef.value[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -128,7 +128,7 @@ const validateURLField = function (field: HTMLInputElement) {
     const key: keyof typeof RequiredURLs =
         field.id as keyof typeof RequiredURLs;
     const fieldValidation = requiredRequiredURLsSchema.shape[key].safeParse(
-        heritageSiteRef.value.urls[key],
+        heritageSiteRef.value[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -162,7 +162,7 @@ const updateAddOtherURL = function () {
 const saveChronology = function () {
     console.log('saveChronology');
     heritageSiteRef.value.siteDetails.chronologies.push({
-        eventType: eventType.value.toString(),
+        eventType: eventType.value?.toString(),
         startYear: startYear.value,
         endYear: endYear.value,
         circa: circa.value,
@@ -272,9 +272,7 @@ onMounted(() => {
                 view="year"
                 aria-describedby="start-year-help"
                 aria-required="true"
-                @update:model-value="
-                    valueChanged($event, 'requiredChronologySchema')
-                "
+                @input="valueChanged($event, 'requiredChronologySchema')"
             />
             <p>End Year</p>
             <DatePicker
@@ -285,9 +283,7 @@ onMounted(() => {
                 view="year"
                 aria-describedby="end-year-help"
                 aria-required="true"
-                @update:model-value="
-                    valueChanged($event, 'requiredChronologySchema')
-                "
+                @input="valueChanged($event, 'requiredChronologySchema')"
             />
             <div class="inline-block">
                 <Checkbox
@@ -394,7 +390,7 @@ onMounted(() => {
                     aria-required="true"
                     fluid
                     class="w-full md:w-14rem"
-                    @update:model-value="
+                    @blur="
                         valueChanged($event, 'requiredArchitectBuilderSchema')
                     "
                 />
@@ -468,6 +464,7 @@ onMounted(() => {
                     id="urlType"
                     ref="urlTypeField"
                     v-model="urlType"
+                    inputId="urlType"
                     placeholder="Select Type"
                     optionLabel="name"
                     :options="urlTypeOptions"
@@ -475,9 +472,7 @@ onMounted(() => {
                     aria-required="true"
                     fluid
                     class="w-full md:w-14rem"
-                    @update:model-value="
-                        valueChanged($event, 'requiredRequiredURLsSchema')
-                    "
+                    @blur="valueChanged($event, 'requiredRequiredURLsSchema')"
                 />
             </LabelledInput>
             <LabelledInput

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -13,6 +13,10 @@ import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePl
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
 import {
+    SiteDetails,
+    Chronology,
+    ArchitectOrBuilder,
+    RequiredURLs,
     requiredSiteDetailsSchema,
     requiredChronologySchema,
     requiredArchitectBuilderSchema,
@@ -66,8 +70,7 @@ const valueChanged = function (event: Event, schema: string) {
 };
 const validateSiteDetailsFields = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
-    const key: keyof typeof HeritageSite =
-        field.id as keyof typeof HeritageSite;
+    const key: keyof typeof SiteDetails = field.id as keyof typeof SiteDetails;
     const fieldValidation = requiredSiteDetailsSchema.shape[key].safeParse(
         heritageSiteRef.value[key],
     );
@@ -85,10 +88,9 @@ const validateSiteDetailsFields = function (field: HTMLInputElement) {
 
 const validateChronologyField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
-    const key: keyof typeof HeritageSite =
-        field.id as keyof typeof HeritageSite;
+    const key: keyof typeof Chronology = field.id as keyof typeof Chronology;
     const fieldValidation = requiredChronologySchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.chronologies[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -104,10 +106,10 @@ const validateChronologyField = function (field: HTMLInputElement) {
 
 const validateArchitectOrBuilderField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
-    const key: keyof typeof HeritageSite =
-        field.id as keyof typeof HeritageSite;
+    const key: keyof typeof ArchitectOrBuilder =
+        field.id as keyof typeof ArchitectOrBuilder;
     const fieldValidation = requiredArchitectBuilderSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.architectsOrBuilders[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -123,10 +125,10 @@ const validateArchitectOrBuilderField = function (field: HTMLInputElement) {
 
 const validateURLField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
-    const key: keyof typeof HeritageSite =
-        field.id as keyof typeof HeritageSite;
+    const key: keyof typeof RequiredURLs =
+        field.id as keyof typeof RequiredURLs;
     const fieldValidation = requiredRequiredURLsSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.urls[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -386,7 +388,6 @@ onMounted(() => {
                     ref="architectOrBuilderTypeField"
                     v-model="architectOrBuilderType"
                     optionLabel="name"
-                    optionValue="code"
                     placeholder="Select Type"
                     :options="architectOrBuilderTypeOptions"
                     aria-describedby="architect-or-builder-type-help"
@@ -469,7 +470,6 @@ onMounted(() => {
                     v-model="urlType"
                     placeholder="Select Type"
                     optionLabel="name"
-                    optionValue="code"
                     :options="urlTypeOptions"
                     aria-describedby="url-type-help"
                     aria-required="true"

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -90,7 +90,7 @@ const validateChronologyField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
     const key: keyof typeof Chronology = field.id as keyof typeof Chronology;
     const fieldValidation = requiredChronologySchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.siteDetails[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -109,7 +109,7 @@ const validateArchitectOrBuilderField = function (field: HTMLInputElement) {
     const key: keyof typeof ArchitectOrBuilder =
         field.id as keyof typeof ArchitectOrBuilder;
     const fieldValidation = requiredArchitectBuilderSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.siteDetails[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');
@@ -128,7 +128,7 @@ const validateURLField = function (field: HTMLInputElement) {
     const key: keyof typeof RequiredURLs =
         field.id as keyof typeof RequiredURLs;
     const fieldValidation = requiredRequiredURLsSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        heritageSiteRef.value.siteDetails[key],
     );
     if (fieldValidation.success) {
         field.classList.remove('p-invalid');

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -7,38 +7,51 @@ import InputText from 'primevue/inputtext';
 import Button from 'primevue/button';
 import Checkbox from 'primevue/checkbox';
 import DatePicker from 'primevue/datepicker';
+import Dropdown from 'primevue/dropdown';
 
 import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePlaceholder/MultiValuePlaceholder.vue';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
-import { requiredHeritageSiteSchema } from '@/bcrhp/schema/HeritageSiteSchema.ts';
+import { requiredSiteDetailsSchema } from '@/bcrhp/schema/SiteDetailsSchema.ts';
 import type { ZodError } from 'zod';
 
 const heritageSite: typeof HeritageSite = inject(
     'heritageSite',
 ) as typeof HeritageSite;
 const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
-const chronology = ref('');
-const chronologies = ref([] as Array<string>);
-const architectOrBuilder = ref('');
-const architectsOrBuilders = ref([] as Array<string>);
-const url = ref('');
-const urls = ref([] as Array<string>);
-const addURLDisabled = ref(false);
 const startYear = ref();
 const endYear = ref();
+const chronologyNotes = ref();
+const chronologies = ref([] as Array<string>);
+const architectOrBuilderName = ref();
+const architectOrBuilderNotes = ref();
+const architectOrBuilderType = ref();
+const architectOrBuilderTypeOptions = ref([
+    { name: 'Architect', code: 'architect' },
+    { name: 'Builder', code: 'builder' },
+]);
+const architectsOrBuilders = ref([] as Array<string>);
+const urlType = ref();
+const linkText = ref();
+const url = ref('');
+const urls = ref([] as Array<string>);
+const urlTypeOptions = ref([
+    { name: 'Historic Place Website', code: 'historic_place_website' },
+    { name: 'Provincial Website', code: 'provincial_website' },
+]);
+const addURLDisabled = ref(false);
 
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
 
 // These names need to match the Zog schema
 const eventType = ref();
-const circa = ref();
+const circa = ref('Exact');
 
 const fields = {
     startYearField: useTemplateRef('startYearField'),
     endYearField: useTemplateRef('endYearField'),
-    chronologyField: useTemplateRef('chronologyField'),
+    chronologyNotesField: useTemplateRef('chronologyNotesField'),
     architectOrBuilderNameField: useTemplateRef('architectOrBuilderNameField'),
     architectOrBuilderTypeField: useTemplateRef('architectOrBuilderTypeField'),
     urlTypeField: useTemplateRef('urlTypeField'),
@@ -84,7 +97,7 @@ const validateField = function (field: HTMLInputElement) {
     console.log(`ID: ${field.id}`);
     const key: keyof typeof HeritageSite =
         field.id as keyof typeof HeritageSite;
-    const fieldValidation = requiredHeritageSiteSchema.shape[key].safeParse(
+    const fieldValidation = requiredSiteDetailsSchema.shape[key].safeParse(
         heritageSiteRef.value[key],
     );
     if (fieldValidation.success) {
@@ -101,59 +114,69 @@ const validateField = function (field: HTMLInputElement) {
 
 const updateAddChronology = function () {
     addURLDisabled.value =
-        chronology.value.length < 1 ||
-        heritageSiteRef.value.chronologies.length > 4;
+        chronologies.value.length < 1 ||
+        heritageSiteRef.value.siteDetails.chronologies.length > 4;
 };
 const updateAddOtherArchitectOrBuilder = function () {
     addURLDisabled.value =
-        architectOrBuilder.value.length < 1 ||
-        heritageSiteRef.value.architectsOrBuilders.length > 4;
+        architectsOrBuilders.value.length < 1 ||
+        heritageSiteRef.value.siteDetails.architectsOrBuilders.length > 4;
 };
 
 const updateAddOtherURL = function () {
     addURLDisabled.value =
-        url.value.length < 1 || heritageSiteRef.value.urls.length > 4;
+        urls.value.length < 1 ||
+        heritageSiteRef.value.siteDetails.urls.length > 4;
 };
 
 const saveChronology = function () {
     console.log('saveChronology');
-    heritageSite.startYear = startYear.value;
-    heritageSite.endYear = endYear.value;
-    heritageSiteRef.value.chronologies.push(chronology.value);
-    architectOrBuilder.value = '';
+    heritageSiteRef.value.siteDetails.chronologies.push({
+        eventType: eventType.value.toString(),
+        startYear: startYear.value,
+        endYear: endYear.value,
+        circa: circa.value,
+        chronologyNotes: chronologyNotes.value,
+    });
 
     updateAddChronology();
 };
 
 const saveArchitectOrBuilder = function () {
     console.log('saveArchitectOrBuilder');
-    heritageSiteRef.value.architectsOrBuilders.push(architectOrBuilder.value);
-    architectOrBuilder.value = '';
+    heritageSiteRef.value.siteDetails.architectsOrBuilders.push({
+        architectOrBuilderName: architectOrBuilderName.value,
+        architectOrBuilderType: architectOrBuilderType.value,
+        architectOrBuilderNotes: architectOrBuilderNotes.value,
+    });
 
     updateAddOtherArchitectOrBuilder();
 };
 const saveURL = function () {
     console.log('saveURL');
-    heritageSiteRef.value.urls.push(url.value);
-    url.value = '';
+    heritageSiteRef.value.siteDetails.urls.push({
+        urlType: urlType.value,
+        linkText: linkText.value,
+        url: url.value,
+    });
 
     updateAddOtherURL();
 };
 
 const deleteChronologyCallback = function (index: number) {
-    heritageSiteRef.value.chronologies.splice(index, 1);
+    heritageSiteRef.value.siteDetails.chronologies.splice(index, 1);
 
     updateAddOtherArchitectOrBuilder();
 };
 
 const deleteArchitectBuilderCallback = function (index: number) {
-    heritageSiteRef.value.architectsOrBuilders.splice(index, 1);
+    heritageSiteRef.value.siteDetails.architectsOrBuilders.splice(index, 1);
 
     updateAddOtherArchitectOrBuilder();
 };
 
 const deleteURLCallback = function (index: number) {
-    heritageSiteRef.value.urls.splice(index, 1);
+    heritageSiteRef.value.siteDetails.urls.splice(index, 1);
 
     updateAddOtherURL();
 };
@@ -165,9 +188,10 @@ let validateFields = false;
 defineExpose({ isValid });
 
 onMounted(() => {
-    heritageSiteRef.value.chronologies = chronologies;
-    heritageSiteRef.value.architectsOrBuilders = architectsOrBuilders;
-    heritageSiteRef.value.urls = urls;
+    heritageSiteRef.value.siteDetails.chronologies = chronologies;
+    heritageSiteRef.value.siteDetails.architectsOrBuilders =
+        architectsOrBuilders;
+    heritageSiteRef.value.siteDetails.urls = urls;
 
     updateAddChronology();
     updateAddOtherArchitectOrBuilder();
@@ -187,24 +211,23 @@ onMounted(() => {
                         <div class="flex items-center gap-2">
                             <Checkbox
                                 v-model="eventType"
-                                inputId="eventType1"
-                                name="construction"
-                                value="construction"
+                                inputId="construction"
+                                value="Construction"
                             />
-                            <label for="eventType1"> Construction </label>
+                            <label for="construction"> Construction </label>
                         </div>
                         <div class="flex items-center gap-2">
                             <Checkbox
                                 v-model="eventType"
-                                inputId="eventType2"
-                                name="significant"
-                                value="significant"
+                                inputId="significant"
+                                value="Significant"
                             />
-                            <label for="eventType2"> Significant </label>
+                            <label for="significant"> Significant </label>
                         </div>
                     </div>
                 </div>
             </div>
+            <p>Start Year</p>
             <DatePicker
                 id="startYear"
                 ref="startYearField"
@@ -214,6 +237,7 @@ onMounted(() => {
                 aria-describedby="start-year-help"
                 aria-required="true"
             />
+            <p>End Year</p>
             <DatePicker
                 id="endYear"
                 ref="endYearField"
@@ -227,8 +251,7 @@ onMounted(() => {
                 <Checkbox
                     v-model="circa"
                     inputId="circa"
-                    name="circa"
-                    value="circa"
+                    value="Circa"
                 />
                 <label for="circa"> Circa </label>
             </div>
@@ -243,17 +266,16 @@ onMounted(() => {
                 <div class="">
                     <InputText
                         id="chronologyNotes"
-                        ref="chronologyField"
-                        v-model:content="heritageSite.chronologyNotes"
+                        ref="chronologyNotesField"
+                        v-model="chronologyNotes"
                         theme="snow"
                         aria-describedby="chronology-help"
-                        aria-required="true"
                         fluid
                         class="inline-block"
                         @editorChange="valueChanged"
                         @focus="onFocusHandler"
                         @blur="onFocusOutHandler"
-                        @update:content="valueUpdated"
+                        @update:model-value="valueUpdated"
                     />
                     <Button
                         id="saveChronology"
@@ -266,12 +288,19 @@ onMounted(() => {
         </div>
         <MultiValuePlaceholder
             v-slot="slotProps"
-            label="Architect(s) / Builder(s)"
+            label="Chronologies"
             :showDeleteButton="true"
             :displayValues="chronologies"
             :deleteCallback="deleteChronologyCallback"
         >
-            <div class="parent value">{{ slotProps.value }}</div>
+            <div
+                v-for="slot in slotProps"
+                :key="slot"
+                class="parent value"
+            >
+                {{ slot.eventType }} {{ slot.circa }} {{ slot.startYear }}
+                {{ slot.endYear }} {{ slot.chronologyNotes }}
+            </div>
         </MultiValuePlaceholder>
     </FieldSet>
     <Fieldset
@@ -279,7 +308,7 @@ onMounted(() => {
         class="p-fieldset p-component mt-2"
         legend="Architects / Builders"
     >
-        <div class="p-inputtext-fluid">
+        <div class="p-inputtext-fluid flex">
             <LabelledInput
                 label="Architect / Builder Name"
                 hint="Enter the company or individual's name"
@@ -292,7 +321,7 @@ onMounted(() => {
                     <InputText
                         id="architectOrBuilderName"
                         ref="architectOrBuilderNameField"
-                        v-model="heritageSite.architectOrBuilderName"
+                        v-model="architectOrBuilderName"
                         aria-describedby="architect-or-builder-help"
                         aria-required="true"
                         fluid
@@ -309,20 +338,19 @@ onMounted(() => {
                 :error-message="errors.architectOrBuilderType?.join(',')"
                 :required="true"
             >
-                <div class="p-inputtext-fluid">
-                    <InputText
-                        id="architectOrBuilderType"
-                        ref="architectOrBuilderTypeField"
-                        v-model="heritageSite.architectOrBuilderType"
-                        aria-describedby="architect-or-builder-type-help"
-                        aria-required="true"
-                        fluid
-                        @change="valueChanged"
-                        @focus="onFocusHandler"
-                        @focusout="onFocusOutHandler"
-                        @update:model-value="valueUpdated"
-                    />
-                </div>
+                <Dropdown
+                    id="architectOrBuilderType"
+                    ref="architectOrBuilderTypeField"
+                    v-model="architectOrBuilderType"
+                    optionLabel="name"
+                    placeholder="Select Type"
+                    :options="architectOrBuilderTypeOptions"
+                    aria-describedby="architect-or-builder-type-help"
+                    aria-required="true"
+                    fluid
+                    class="w-full md:w-14rem"
+                    @update:model-value="valueUpdated"
+                />
             </LabelledInput>
         </div>
         <div class="p-inputtext-fluid">
@@ -337,7 +365,7 @@ onMounted(() => {
                     <InputText
                         id="architectOrBuilderNotes"
                         ref="architectOrBuilderNotesField"
-                        v-model="heritageSite.architectOrBuilderNotes"
+                        v-model="architectOrBuilderNotes"
                         aria-describedby="architect-or-builder-notes-help"
                         aria-required="true"
                         fluid
@@ -363,7 +391,15 @@ onMounted(() => {
             :displayValues="architectsOrBuilders"
             :deleteCallback="deleteArchitectBuilderCallback"
         >
-            <div class="parent value">{{ slotProps.value }}</div>
+            <div
+                v-for="slot in slotProps"
+                :key="slot"
+                class="parent value"
+            >
+                {{ slot.architectOrBuilderType?.name }}
+                {{ slot.architectOrBuilderName }}
+                {{ slot.architectOrBuilderNotes }}
+            </div>
         </MultiValuePlaceholder>
     </Fieldset>
     <Fieldset
@@ -379,20 +415,19 @@ onMounted(() => {
                 :error-message="errors.urlType?.join(',')"
                 :required="true"
             >
-                <div class="p-inputtext-fluid">
-                    <InputText
-                        id="urlType"
-                        ref="urlTypeField"
-                        v-model="heritageSite.urlType"
-                        aria-describedby="url-type-help"
-                        aria-required="true"
-                        fluid
-                        @change="valueChanged"
-                        @focus="onFocusHandler"
-                        @focusout="onFocusOutHandler"
-                        @update:model-value="valueUpdated"
-                    />
-                </div>
+                <Dropdown
+                    id="urlType"
+                    ref="urlTypeField"
+                    v-model="urlType"
+                    placeholder="Select Type"
+                    optionLabel="name"
+                    :options="urlTypeOptions"
+                    aria-describedby="url-type-help"
+                    aria-required="true"
+                    fluid
+                    class="w-full md:w-14rem"
+                    @update:model-value="valueUpdated"
+                />
             </LabelledInput>
             <LabelledInput
                 label="Link Text"
@@ -405,7 +440,7 @@ onMounted(() => {
                     <InputText
                         id="linkText"
                         ref="linkTextField"
-                        v-model="heritageSite.linkText"
+                        v-model="linkText"
                         aria-describedby="link-text-help"
                         aria-required="true"
                         fluid
@@ -454,7 +489,13 @@ onMounted(() => {
                 :displayValues="urls"
                 :deleteCallback="deleteURLCallback"
             >
-                <div class="parent value">{{ slotProps.value }}</div>
+                <div
+                    v-for="slot in slotProps"
+                    :key="slot"
+                    class="parent value"
+                >
+                    {{ slot.urlType?.name }} {{ slot.url }} {{ slot.linkText }}
+                </div>
             </MultiValuePlaceholder>
         </div>
     </Fieldset>

--- a/bcrhp/src/bcrhp/schema/HeritageSiteSchema.ts
+++ b/bcrhp/src/bcrhp/schema/HeritageSiteSchema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { CivicAddressSchema } from '@/bcrhp/schema/CivicAddressSchema.ts';
-import { UploadImageSchema } from '@/bcrhp/schema/UploadImageSchema.ts';
+import { SiteImagesSchema } from '@/bcrhp/schema/SiteImagesSchema.ts';
 import { RecognitionDetails } from '@/bcrhp/schema/RecognitionDetailsSchema.ts';
 import { StatementOfSignificance } from '@/bcrhp/schema/StatementOfSignificanceSchema.ts';
 import { SiteClassification } from '@/bcrhp/schema/SiteClassificationSchema.ts';
@@ -19,7 +19,7 @@ const HeritageSiteSchema = z.object({
     commonName: z.string().min(1, { message: 'Common Name is required.' }),
     otherNames: z.array(z.string()).max(5),
     civicAddress: z.array(CivicAddressSchema),
-    uploadImage: z.array(UploadImageSchema),
+    siteImages: z.array(SiteImagesSchema),
     recognitionDetails: z.array(RecognitionDetails),
     statementOfSignificance: z.array(StatementOfSignificance),
     siteClassification: z.array(SiteClassification),
@@ -50,7 +50,7 @@ class HeritageSite implements HeritageSiteType {
         this.otherNames = [];
         this.hasCivicAddress = true;
         this.civicAddress = {}; // Object of UUID -> CivicAddress objects
-        this.uploadImage = {};
+        this.siteImages = {};
         this.siteBoundary = {};
         this.recognitionDetails = {};
         this.statementOfSignificance = {};
@@ -67,7 +67,7 @@ class HeritageSite implements HeritageSiteType {
     otherNames: string[];
     hasCivicAddress: boolean;
     civicAddress: object;
-    uploadImage: object;
+    siteImages: object;
     recognitionDetails: object;
     statementOfSignificance: object;
     siteClassification: object;

--- a/bcrhp/src/bcrhp/schema/HeritageSiteSchema.ts
+++ b/bcrhp/src/bcrhp/schema/HeritageSiteSchema.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { CivicAddressSchema } from '@/bcrhp/schema/CivicAddressSchema.ts';
 import { UploadImageSchema } from '@/bcrhp/schema/UploadImageSchema.ts';
+import { RecognitionDetails } from '@/bcrhp/schema/RecognitionDetailsSchema.ts';
+import { StatementOfSignificance } from '@/bcrhp/schema/StatementOfSignificanceSchema.ts';
+import { SiteClassification } from '@/bcrhp/schema/SiteClassificationSchema.ts';
+import { SiteDetails } from '@/bcrhp/schema/SiteDetailsSchema.ts';
 
 const HeritageSiteSchema = z.object({
     siteId: z.string().uuid(),
@@ -16,74 +20,12 @@ const HeritageSiteSchema = z.object({
     otherNames: z.array(z.string()).max(5),
     civicAddress: z.array(CivicAddressSchema),
     uploadImage: z.array(UploadImageSchema),
+    recognitionDetails: z.array(RecognitionDetails),
+    statementOfSignificance: z.array(StatementOfSignificance),
+    siteClassification: z.array(SiteClassification),
+    siteDetails: z.array(SiteDetails),
     siteBoundary: z.object(), // This needs to map to a GeoJSON object
     siteBoundaryIncorrect: z.boolean().default(false), // If the geometry from the PID isn't right this flags it
-    designationDate: z
-        .string()
-        .min(1, { message: 'Designation Date is required.' })
-        .max(12),
-    legislativeAct: z
-        .string()
-        .min(1, { message: 'Legislative Act is required.' })
-        .max(250),
-    referenceNumber: z
-        .string()
-        .min(1, { message: 'Reference Number is required.' })
-        .max(12),
-    referenceNumbers: z.array(z.string()).max(12),
-    description: z
-        .string()
-        .min(1, { message: 'Description is required.' })
-        .max(4000),
-    heritageValue: z
-        .string()
-        .min(1, { message: 'Heritage Value is required.' })
-        .max(4000),
-    definingElements: z
-        .string()
-        .min(1, { message: 'Defining Elements is required.' })
-        .max(4000),
-    documentLocation: z
-        .string()
-        .min(1, { message: 'Document Location is required.' })
-        .max(250),
-    contributingResources: z
-        .string()
-        .min(1, { message: 'Number of Contributing Resources is required.' })
-        .max(250),
-    totalContributingResources: z.array(z.string()).max(5),
-    functionCategory: z
-        .string()
-        .min(1, { message: 'Function Category is required.' })
-        .max(250),
-    functionCategories: z.array(z.string()).max(5),
-    heritageTheme: z
-        .string()
-        .min(1, { message: 'Heritage Theme is required.' })
-        .max(250),
-    heritageThemes: z.array(z.string()).max(5),
-    chronology: z
-        .string()
-        .min(1, { message: 'Chronology is required.' })
-        .max(250),
-    chronologies: z.array(z.string()).max(5),
-    startYear: z.array(z.string()).max(4),
-    endYear: z.array(z.string()).max(4),
-    architectOrBuilderName: z
-        .string()
-        .min(1, { message: 'Architect or Builder Name is required.' })
-        .max(250),
-    architectOrBuilderNotes: z.string().max(4000),
-    architectOrBuilderType: z
-        .string()
-        .min(1, { message: 'Architect or Builder Type is required.' })
-        .max(250),
-    architectsOrBuilders: z.array(z.string()).max(5),
-    urlType: z.array(z.string()).max(250),
-    urlText: z.string().min(1, { message: 'URL Type is required.' }).max(250),
-    linkText: z.string().min(1, { message: 'URL Text is required.' }).max(250),
-    url: z.string().min(1, { message: 'URL is required.' }).max(250),
-    urls: z.array(z.string()).max(5),
     otherName: z.array(z.string()).max(12),
     documentDescription: z.string().max(250),
     submissionNotes: z.string().max(250),
@@ -110,34 +52,11 @@ class HeritageSite implements HeritageSiteType {
         this.civicAddress = {}; // Object of UUID -> CivicAddress objects
         this.uploadImage = {};
         this.siteBoundary = {};
+        this.recognitionDetails = {};
+        this.statementOfSignificance = {};
+        this.siteClassification = {};
+        this.siteDetails = {};
         this.siteBoundaryIncorrect = false;
-        this.designationDate = '';
-        this.legislativeAct = '';
-        this.showInactiveHistoricActs = false;
-        this.referenceNumber = '';
-        this.referenceNumbers = [];
-        this.description = '';
-        this.heritageValue = '';
-        this.definingElements = '';
-        this.documentLocation = '';
-        this.contributingResources = '';
-        this.totalContributingResources = [];
-        this.functionCategory = '';
-        this.functionCategories = [];
-        this.heritageTheme = '';
-        this.heritageThemes = [];
-        this.chronology = '';
-        this.chronologies = [];
-        this.startYear = '';
-        this.endYear = '';
-        this.architectOrBuilderName = '';
-        this.architectOrBuilderNotes = '';
-        this.architectOrBuilderType = '';
-        this.architectsOrBuilders = [];
-        this.urlType = '';
-        this.linkText = '';
-        this.url = '';
-        this.urls = [];
         this.otherName = '';
         this.documentDescription = '';
         this.submissionNotes = '';
@@ -149,35 +68,12 @@ class HeritageSite implements HeritageSiteType {
     hasCivicAddress: boolean;
     civicAddress: object;
     uploadImage: object;
+    recognitionDetails: object;
+    statementOfSignificance: object;
+    siteClassification: object;
+    siteDetails: object;
     siteBoundary: object;
     siteBoundaryIncorrect: boolean;
-    designationDate: string;
-    legislativeAct: string;
-    showInactiveHistoricActs: boolean;
-    referenceNumber: string;
-    referenceNumbers: string[];
-    description: string;
-    heritageValue: string;
-    definingElements: string;
-    documentLocation: string;
-    contributingResources: string;
-    totalContributingResources: string[];
-    functionCategory: string;
-    functionCategories: string[];
-    heritageTheme: string;
-    heritageThemes: string[];
-    chronology: string;
-    chronologies: string[];
-    startYear: string;
-    endYear: string;
-    architectOrBuilderName: string;
-    architectOrBuilderNotes: string;
-    architectOrBuilderType: string;
-    architectsOrBuilders: string[];
-    urlType: string;
-    linkText: string;
-    url: string;
-    urls: string[];
     otherName: string;
     documentDescription: string;
     submissionNotes: string;

--- a/bcrhp/src/bcrhp/schema/RecognitionDetailsSchema.ts
+++ b/bcrhp/src/bcrhp/schema/RecognitionDetailsSchema.ts
@@ -29,13 +29,11 @@ class RecognitionDetails implements RecognitionDetailsType {
     constructor() {
         this.designationDate = '';
         this.legislativeAct = '';
-        this.showInactiveHistoricActs = false;
         this.referenceNumber = '';
         this.totalRecognitionDetails = [];
     }
     designationDate: string;
     legislativeAct: string;
-    showInactiveHistoricActs: boolean;
     referenceNumber: string;
     totalRecognitionDetails: string[];
 }

--- a/bcrhp/src/bcrhp/schema/RecognitionDetailsSchema.ts
+++ b/bcrhp/src/bcrhp/schema/RecognitionDetailsSchema.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+const RecognitionDetailsSchema = z.object({
+    designationDate: z
+        .string()
+        .min(1, { message: 'Designation Date is required.' })
+        .max(12),
+    legislativeAct: z
+        .string()
+        .min(1, { message: 'Legislative Act is required.' })
+        .max(250),
+    referenceNumber: z
+        .string()
+        .min(1, { message: 'Reference Number is required.' })
+        .max(12),
+    totalRecognitionDetails: z.array(z.string()).max(12),
+});
+
+const requiredRecognitionDetailsSchema = RecognitionDetailsSchema.partial({});
+// @ts-ignore
+type RecognitionDetailsType = z.infer<typeof RecognitionDetailsSchema>;
+
+function getRecognitionDetails(): RecognitionDetailsType {
+    return new RecognitionDetails();
+}
+
+// @todo - Figure out object state - New/Updated/Deleted
+class RecognitionDetails implements RecognitionDetailsType {
+    constructor() {
+        this.designationDate = '';
+        this.legislativeAct = '';
+        this.showInactiveHistoricActs = false;
+        this.referenceNumber = '';
+        this.totalRecognitionDetails = [];
+    }
+    designationDate: string;
+    legislativeAct: string;
+    showInactiveHistoricActs: boolean;
+    referenceNumber: string;
+    totalRecognitionDetails: string[];
+}
+
+export {
+    RecognitionDetails,
+    RecognitionDetailsSchema,
+    getRecognitionDetails,
+    requiredRecognitionDetailsSchema,
+};

--- a/bcrhp/src/bcrhp/schema/SiteClassificationSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteClassificationSchema.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+
+const SiteClassificationSchema = z.object({
+    contributingResources: z
+        .string()
+        .min(1, { message: 'Number of Contributing Resources is required.' })
+        .max(250),
+    heritageClasses: z.array(z.string()).max(5),
+    functionCategory: z
+        .string()
+        .min(1, { message: 'Function Category is required.' })
+        .max(250),
+    heritageFunctions: z.array(z.string()).max(5),
+    heritageTheme: z
+        .string()
+        .min(1, { message: 'Heritage Theme is required.' })
+        .max(250),
+    heritageThemes: z.array(z.string()).max(5),
+});
+
+const requiredSiteClassificationSchema = SiteClassificationSchema.partial({});
+// @ts-ignore
+type SiteClassificationType = z.infer<typeof SiteClassificationSchema>;
+
+function getSiteClassificationSchema(): SiteClassificationType {
+    return new SiteClassification();
+}
+
+// @todo - Figure out object state - New/Updated/Deleted
+class SiteClassification implements SiteClassificationType {
+    constructor() {
+        this.contributingResources = '';
+        this.heritageClasses = [];
+        this.heritageCategory = '';
+        this.ownership = '';
+        this.functionCategory = '';
+        this.functionCategoryType = '';
+        this.heritageFunctions = [];
+        this.heritageTheme = '';
+        this.heritageThemes = [];
+    }
+    contributingResources: string;
+    heritageClasses: string[];
+    heritageCategory: string;
+    ownership: string;
+    functionCategory: string;
+    functionCategoryType: string;
+    heritageFunctions: string[];
+    heritageTheme: string;
+    heritageThemes: string[];
+}
+
+export {
+    SiteClassification,
+    SiteClassificationSchema,
+    getSiteClassificationSchema,
+    requiredSiteClassificationSchema,
+};

--- a/bcrhp/src/bcrhp/schema/SiteClassificationSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteClassificationSchema.ts
@@ -1,53 +1,103 @@
 import { z } from 'zod';
 
 const SiteClassificationSchema = z.object({
+    heritageClasses: z.array(z.string()).max(5),
+    heritageFunctions: z.array(z.string()).max(5),
+    heritageThemes: z.array(z.string()).max(5),
+});
+const HeritageClassSchema = z.object({
     contributingResources: z
-        .string()
+        .number()
         .min(1, { message: 'Number of Contributing Resources is required.' })
         .max(250),
-    heritageClasses: z.array(z.string()).max(5),
+    heritageCategory: z
+        .string()
+        .min(1, { message: 'Heritage Category is required.' })
+        .max(250),
+    ownership: z
+        .string()
+        .min(1, { message: 'Ownership is required.' })
+        .max(250),
+});
+const HeritageFunctionSchema = z.object({
     functionCategory: z
         .string()
         .min(1, { message: 'Function Category is required.' })
         .max(250),
-    heritageFunctions: z.array(z.string()).max(5),
+    functionCategoryType: z.string().max(12),
+});
+const HeritageThemeSchema = z.object({
     heritageTheme: z
         .string()
         .min(1, { message: 'Heritage Theme is required.' })
         .max(250),
-    heritageThemes: z.array(z.string()).max(5),
 });
 
 const requiredSiteClassificationSchema = SiteClassificationSchema.partial({});
+const requiredHeritageClassSchema = HeritageClassSchema.partial({});
+const requiredHeritageFunctionSchema = HeritageFunctionSchema.partial({});
+const requiredHeritageThemeSchema = HeritageThemeSchema.partial({});
+
 // @ts-ignore
 type SiteClassificationType = z.infer<typeof SiteClassificationSchema>;
+// @ts-ignore
+type HeritageClassType = z.infer<typeof HeritageClassSchema>;
+// @ts-ignore
+type HeritageFunctionType = z.infer<typeof HeritageFunctionSchema>;
+// @ts-ignore
+type HeritageThemeType = z.infer<typeof HeritageThemeSchema>;
 
 function getSiteClassificationSchema(): SiteClassificationType {
     return new SiteClassification();
+}
+function getHeritageClassSchema(): HeritageClassType {
+    return new HeritageClass();
+}
+function getHeritageFunctionSchema(): HeritageFunctionType {
+    return new HeritageFunction();
+}
+
+function getHeritageThemeSchema(): HeritageThemeType {
+    return new HeritageTheme();
 }
 
 // @todo - Figure out object state - New/Updated/Deleted
 class SiteClassification implements SiteClassificationType {
     constructor() {
-        this.contributingResources = '';
         this.heritageClasses = [];
-        this.heritageCategory = '';
-        this.ownership = '';
-        this.functionCategory = '';
-        this.functionCategoryType = '';
         this.heritageFunctions = [];
-        this.heritageTheme = '';
         this.heritageThemes = [];
     }
-    contributingResources: string;
     heritageClasses: string[];
+    heritageFunctions: string[];
+    heritageThemes: string[];
+}
+
+class HeritageClass implements HeritageClassType {
+    constructor() {
+        this.contributingResources = 0;
+        this.heritageCategory = '';
+        this.ownership = '';
+    }
+    contributingResources: number;
     heritageCategory: string;
     ownership: string;
+}
+
+class HeritageFunction implements HeritageFunctionType {
+    constructor() {
+        this.functionCategory = '';
+        this.functionCategoryType = '';
+    }
     functionCategory: string;
     functionCategoryType: string;
-    heritageFunctions: string[];
+}
+
+class HeritageTheme implements HeritageThemeType {
+    constructor() {
+        this.heritageTheme = '';
+    }
     heritageTheme: string;
-    heritageThemes: string[];
 }
 
 export {
@@ -55,4 +105,16 @@ export {
     SiteClassificationSchema,
     getSiteClassificationSchema,
     requiredSiteClassificationSchema,
+    HeritageClass,
+    HeritageClassSchema,
+    getHeritageClassSchema,
+    requiredHeritageClassSchema,
+    HeritageFunction,
+    HeritageFunctionSchema,
+    getHeritageFunctionSchema,
+    requiredHeritageFunctionSchema,
+    HeritageTheme,
+    HeritageThemeSchema,
+    getHeritageThemeSchema,
+    requiredHeritageThemeSchema,
 };

--- a/bcrhp/src/bcrhp/schema/SiteDetailsSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteDetailsSchema.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+const SiteDetailsSchema = z.object({
+    startYear: z.array(z.string()).max(4),
+    endYear: z.array(z.string()).max(4),
+    chronologyNotes: z.string().max(1000),
+    chronologies: z.array(z.string()).max(5),
+    architectOrBuilderName: z
+        .string()
+        .min(1, { message: 'Architect or Builder Name is required.' })
+        .max(250),
+    architectOrBuilderNotes: z.string().max(4000),
+    architectOrBuilderType: z
+        .string()
+        .min(1, { message: 'Architect or Builder Type is required.' })
+        .max(250),
+    architectsOrBuilders: z.array(z.string()).max(5),
+    urlType: z.array(z.string()).max(250),
+    urlText: z.string().min(1, { message: 'URL Type is required.' }).max(250),
+    linkText: z.string().min(1, { message: 'URL Text is required.' }).max(250),
+    url: z.string().min(1, { message: 'URL is required.' }).max(250),
+    urls: z.array(z.string()).max(5),
+});
+
+const requiredSiteDetailsSchema = SiteDetailsSchema.partial({});
+// @ts-ignore
+type SiteDetailsType = z.infer<typeof SiteDetailsSchema>;
+
+function getSiteDetailsSchema(): SiteDetailsType {
+    return new SiteDetails();
+}
+
+// @todo - Figure out object state - New/Updated/Deleted
+class SiteDetails implements SiteDetailsType {
+    constructor() {
+        this.eventType = '';
+        this.startYear = '';
+        this.endYear = '';
+        this.circa = '';
+        this.chronologyNotes = '';
+        this.chronologies = [];
+        this.architectOrBuilderName = '';
+        this.architectOrBuilderNotes = '';
+        this.architectOrBuilderType = '';
+        this.architectsOrBuilders = [];
+        this.urlType = '';
+        this.linkText = '';
+        this.url = '';
+        this.urls = [];
+    }
+    eventType: string;
+    startYear: string;
+    endYear: string;
+    circa: string;
+    chronologyNotes: string;
+    chronologies: string[];
+    architectOrBuilderName: string;
+    architectOrBuilderNotes: string;
+    architectOrBuilderType: string;
+    architectsOrBuilders: string[];
+    urlType: string;
+    linkText: string;
+    url: string;
+    urls: string[];
+}
+
+export {
+    SiteDetails,
+    SiteDetailsSchema,
+    getSiteDetailsSchema,
+    requiredSiteDetailsSchema,
+};

--- a/bcrhp/src/bcrhp/schema/SiteDetailsSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteDetailsSchema.ts
@@ -1,10 +1,18 @@
 import { z } from 'zod';
 
 const SiteDetailsSchema = z.object({
+    chronologies: z.array(z.string()).max(5),
+    architectsOrBuilders: z.array(z.string()).max(5),
+    urls: z.array(z.string()).max(5),
+});
+const ChronologySchema = z.object({
+    eventType: z.string().max(20),
     startYear: z.array(z.string()).max(4),
     endYear: z.array(z.string()).max(4),
+    circa: z.string().max(20),
     chronologyNotes: z.string().max(1000),
-    chronologies: z.array(z.string()).max(5),
+});
+const ArchitectBuilderSchema = z.object({
     architectOrBuilderName: z
         .string()
         .min(1, { message: 'Architect or Builder Name is required.' })
@@ -14,54 +22,85 @@ const SiteDetailsSchema = z.object({
         .string()
         .min(1, { message: 'Architect or Builder Type is required.' })
         .max(250),
-    architectsOrBuilders: z.array(z.string()).max(5),
+});
+const RequiredURLsSchema = z.object({
     urlType: z.array(z.string()).max(250),
     urlText: z.string().min(1, { message: 'URL Type is required.' }).max(250),
     linkText: z.string().min(1, { message: 'URL Text is required.' }).max(250),
     url: z.string().min(1, { message: 'URL is required.' }).max(250),
-    urls: z.array(z.string()).max(5),
 });
 
 const requiredSiteDetailsSchema = SiteDetailsSchema.partial({});
+const requiredChronologySchema = ChronologySchema.partial({});
+const requiredArchitectBuilderSchema = ArchitectBuilderSchema.partial({});
+const requiredRequiredURLsSchema = RequiredURLsSchema.partial({});
+
 // @ts-ignore
 type SiteDetailsType = z.infer<typeof SiteDetailsSchema>;
+// @ts-ignore
+type ChronologyType = z.infer<typeof ChronologySchema>;
+// @ts-ignore
+type ArchitectOrBuilderType = z.infer<typeof ArchitectOrBuilderSchema>;
+// @ts-ignore
+type RequiredURLsType = z.infer<typeof RequiredURLsSchema>;
 
 function getSiteDetailsSchema(): SiteDetailsType {
     return new SiteDetails();
 }
+function getChronologySchema(): ChronologyType {
+    return new Chronology();
+}
+function getArchitectOrBuilderSchema(): ArchitectOrBuilderType {
+    return new ArchitectOrBuilder();
+}
+function getRequiredURLsSchema(): RequiredURLsType {
+    return new RequiredURLs();
+}
 
 // @todo - Figure out object state - New/Updated/Deleted
 class SiteDetails implements SiteDetailsType {
+    constructor() {
+        this.chronologies = [];
+        this.architectsOrBuilders = [];
+        this.urls = [];
+    }
+    chronologies: string[];
+    architectsOrBuilders: string[];
+    urls: string[];
+}
+class Chronology implements ChronologyType {
     constructor() {
         this.eventType = '';
         this.startYear = '';
         this.endYear = '';
         this.circa = '';
         this.chronologyNotes = '';
-        this.chronologies = [];
-        this.architectOrBuilderName = '';
-        this.architectOrBuilderNotes = '';
-        this.architectOrBuilderType = '';
-        this.architectsOrBuilders = [];
-        this.urlType = '';
-        this.linkText = '';
-        this.url = '';
-        this.urls = [];
     }
     eventType: string;
     startYear: string;
     endYear: string;
     circa: string;
     chronologyNotes: string;
-    chronologies: string[];
+}
+class ArchitectOrBuilder implements ArchitectOrBuilderType {
+    constructor() {
+        this.architectOrBuilderName = '';
+        this.architectOrBuilderNotes = '';
+        this.architectOrBuilderType = '';
+    }
     architectOrBuilderName: string;
     architectOrBuilderNotes: string;
     architectOrBuilderType: string;
-    architectsOrBuilders: string[];
+}
+class RequiredURLs implements RequiredURLsType {
+    constructor() {
+        this.urlType = '';
+        this.linkText = '';
+        this.url = '';
+    }
     urlType: string;
     linkText: string;
     url: string;
-    urls: string[];
 }
 
 export {
@@ -69,4 +108,16 @@ export {
     SiteDetailsSchema,
     getSiteDetailsSchema,
     requiredSiteDetailsSchema,
+    Chronology,
+    ChronologySchema,
+    getChronologySchema,
+    requiredChronologySchema,
+    ArchitectOrBuilder,
+    ArchitectBuilderSchema,
+    getArchitectOrBuilderSchema,
+    requiredArchitectBuilderSchema,
+    RequiredURLs,
+    RequiredURLsSchema,
+    getRequiredURLsSchema,
+    requiredRequiredURLsSchema,
 };

--- a/bcrhp/src/bcrhp/schema/SiteImagesSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteImagesSchema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-const UploadImageSchema = z.object({
+const SiteImagesSchema = z.object({
     imageType: z
         .string()
         .min(1, { message: 'Image Type is required.' })
@@ -22,16 +22,16 @@ const UploadImageSchema = z.object({
     copyright: z.string().max(250),
 });
 
-const requiredUploadImageSchema = UploadImageSchema.partial({});
+const requiredSiteImagesSchema = SiteImagesSchema.partial({});
 // @ts-ignore
-type UploadImageType = z.infer<typeof UploadImageSchema>;
+type SiteImagesType = z.infer<typeof SiteImagesSchema>;
 
-function getUploadImage(): UploadImageType {
-    return new UploadImage();
+function getSiteImages(): SiteImagesType {
+    return new SiteImages();
 }
 
 // @todo - Figure out object state - New/Updated/Deleted
-class UploadImage implements UploadImageType {
+class SiteImages implements SiteImagesType {
     constructor() {
         this.imageType = '';
         this.imageView = '';
@@ -51,8 +51,8 @@ class UploadImage implements UploadImageType {
 }
 
 export {
-    UploadImage,
-    UploadImageSchema,
-    getUploadImage,
-    requiredUploadImageSchema,
+    SiteImages,
+    SiteImagesSchema,
+    getSiteImages,
+    requiredSiteImagesSchema,
 };

--- a/bcrhp/src/bcrhp/schema/StatementOfSignificanceSchema.ts
+++ b/bcrhp/src/bcrhp/schema/StatementOfSignificanceSchema.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+const StatementOfSignificanceSchema = z.object({
+    description: z
+        .string()
+        .min(1, { message: 'Description is required.' })
+        .max(4000),
+    heritageValue: z
+        .string()
+        .min(1, { message: 'Heritage Value is required.' })
+        .max(4000),
+    definingElements: z
+        .string()
+        .min(1, { message: 'Defining Elements is required.' })
+        .max(4000),
+    documentLocation: z
+        .string()
+        .min(1, { message: 'Document Location is required.' })
+        .max(250),
+});
+
+const requiredStatementOfSignificanceSchema =
+    StatementOfSignificanceSchema.partial({});
+// @ts-ignore
+type StatementOfSignificanceType = z.infer<
+    typeof StatementOfSignificanceSchema
+>;
+
+function getStatementOfSignificance(): StatementOfSignificanceType {
+    return new StatementOfSignificance();
+}
+
+// @todo - Figure out object state - New/Updated/Deleted
+class StatementOfSignificance implements StatementOfSignificanceType {
+    constructor() {
+        this.description = '';
+        this.heritageValue = '';
+        this.definingElements = '';
+        this.documentLocation = '';
+    }
+    description: string;
+    heritageValue: string;
+    definingElements: string;
+    documentLocation: string;
+}
+
+export {
+    StatementOfSignificance,
+    StatementOfSignificanceSchema,
+    getStatementOfSignificance,
+    requiredStatementOfSignificanceSchema,
+};

--- a/components.d.ts
+++ b/components.d.ts
@@ -8,9 +8,11 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    Checkbox: typeof import('primevue/checkbox')['default']
     DatePicker: typeof import('primevue/datepicker')['default']
     Fieldset: typeof import('primevue/fieldset')['default']
     FileUpload: typeof import('primevue/fileupload')['default']
+    InputText: typeof import('primevue/inputtext')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
   }


### PR DESCRIPTION
This PR does the following:

- Add an individual validation schema for each step and update each relevant component to use it instead of HeritageSchema.ts
- Update the Step11_ReviewSubmission.vue component to show multiple relationships/items, if they exist
- Update each component to properly display multiple relationships/items if they exist using the MultiValuePlaceholder component
-  Fix minor bugs in several components (mainly wrong variable names/values copied over from previous components)

Known bugs:
- The 'Add' button on Step5_RecognitionDetails, Step7_Images, Step8_SiteClassification and Step9_SiteDetails does not get properly disabled when no values are entered
- It's possible to add an empty item due to the 'Add' button always being enabled
- CivicAddress is not yet shown on the Step11_ReviewSubmission page