### PR TITLE
1264 - Apply LOVs to Image fields add UUID to Image schema

### DIFF
--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -6,8 +6,6 @@ import InputText from 'primevue/inputtext';
 import Editor from 'primevue/editor';
 import DatePicker from 'primevue/datepicker';
 
-import { fetchConcepts } from '@/bcgov_arches_common/api.ts';
-
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import ConceptSelect from '@/bcgov_arches_common/components/ConceptSelect/ConceptSelect.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
@@ -102,9 +100,6 @@ const onImageUpload = function () {};
 // configuration so API methods are not
 defineExpose({ isValid });
 
-// Lookup values
-const imageTypes = ref();
-
 const updateImageType = function (
     newValue: string,
     selectField: typeof ConceptSelect,
@@ -113,9 +108,7 @@ const updateImageType = function (
     currentSiteImage.value[selectField.id] = newValue;
 };
 
-onMounted(() => {
-    fetchConcepts('b4f84f28-e64b-4285-a8e4-0bacf36e1101', imageTypes);
-});
+onMounted(() => {});
 </script>
 <template>
     <div class="flex flex-row">

--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -6,20 +6,27 @@ import InputText from 'primevue/inputtext';
 import Editor from 'primevue/editor';
 import DatePicker from 'primevue/datepicker';
 
+import { fetchConcepts } from '@/bcgov_arches_common/api.ts';
+
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
+import ConceptSelect from '@/bcgov_arches_common/components/ConceptSelect/ConceptSelect.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
 import {
     SiteImages,
     requiredSiteImagesSchema,
+    getSiteImages,
 } from '@/bcrhp/schema/SiteImagesSchema.ts';
 import type { ZodError } from 'zod';
 
 const heritageSite: typeof HeritageSite = inject(
     'heritageSite',
 ) as typeof HeritageSite;
-const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
+
+const currentSiteImage = ref(getSiteImages());
+currentSiteImage.value.imageTypes = [];
+heritageSite.value.siteImages[currentSiteImage.value.id] = currentSiteImage;
 
 // These names need to match the Zog schema
 const fields = {
@@ -71,7 +78,7 @@ const validateField = function (field: HTMLInputElement) {
 
     const key: keyof typeof SiteImages = field.id as keyof typeof SiteImages;
     const fieldValidation = requiredSiteImagesSchema.shape[key].safeParse(
-        heritageSiteRef.value.siteImages[key],
+        currentSiteImage.value[key],
     );
 
     if (fieldValidation.success) {
@@ -95,7 +102,20 @@ const onImageUpload = function () {};
 // configuration so API methods are not
 defineExpose({ isValid });
 
-onMounted(() => {});
+// Lookup values
+const imageTypes = ref();
+
+const updateImageType = function (
+    newValue: string,
+    selectField: typeof ConceptSelect,
+) {
+    console.log(`New value ${newValue}`);
+    currentSiteImage.value[selectField.id] = newValue;
+};
+
+onMounted(() => {
+    fetchConcepts('b4f84f28-e64b-4285-a8e4-0bacf36e1101', imageTypes);
+});
 </script>
 <template>
     <div class="flex flex-row">
@@ -119,17 +139,14 @@ onMounted(() => {});
             :required="true"
         >
             <div class="p-inputtext-fluid">
-                <InputText
+                <ConceptSelect
                     id="imageType"
                     ref="imageTypeField"
-                    v-model="heritageSite.siteImages.imageType"
-                    aria-describedby="image-type-help"
-                    aria-required="true"
-                    fluid
-                    @change="valueChanged"
-                    @focus="onFocusHandler"
-                    @focusout="onFocusOutHandler"
-                    @update:model-value="valueUpdated"
+                    graph-slug="heritage_site"
+                    node-alias="image_type"
+                    model-value="currentSiteImage.imageType"
+                    placeholder="Select an Image Type"
+                    @value-updated="updateImageType"
                 />
             </div>
         </LabelledInput>
@@ -141,18 +158,14 @@ onMounted(() => {});
             :required="true"
         >
             <div class="p-inputtext-fluid">
-                <InputText
+                <ConceptSelect
                     id="imageView"
                     ref="imageViewField"
-                    v-model="heritageSite.siteImages.imageView"
-                    aria-describedby="image-view-help"
-                    aria-required="true"
-                    fluid
-                    class="inline-block"
-                    @change="valueChanged"
-                    @focus="onFocusHandler"
-                    @focusout="onFocusOutHandler"
-                    @update:model-value="valueUpdated"
+                    graph-slug="heritage_site"
+                    node-alias="image_view"
+                    model-value="currentSiteImage.imageView"
+                    placeholder="Select an Image View"
+                    @value-updated="updateImageType"
                 />
             </div>
         </LabelledInput>
@@ -169,7 +182,6 @@ onMounted(() => {});
                 ref="imageFeaturesField"
                 v-model="heritageSite.siteImages.imageFeatures"
                 aria-describedby="image-features-help"
-                aria-required="true"
                 fluid
                 class="inline-block"
                 @change="valueChanged"
@@ -190,6 +202,7 @@ onMounted(() => {});
             id="imageDate"
             ref="imageDateField"
             v-model="heritageSite.siteImages.imageDate"
+            show-icon
             aria-describedby="image-date-help"
             aria-required="true"
         />
@@ -262,15 +275,3 @@ onMounted(() => {});
         </div>
     </LabelledInput>
 </template>
-
-<style scoped>
-.inline-block {
-    display: inline-block;
-    width: unset;
-}
-
-.p-inputtext-fluid.inline-block {
-    width: calc(100% - 6.5rem);
-    margin-right: 1rem;
-}
-</style>

--- a/bcrhp/src/bcrhp/schema/SiteImagesSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteImagesSchema.ts
@@ -33,6 +33,7 @@ function getSiteImages(): SiteImagesType {
 // @todo - Figure out object state - New/Updated/Deleted
 class SiteImages implements SiteImagesType {
     constructor() {
+        this.id = crypto.randomUUID();
         this.imageType = '';
         this.imageView = '';
         this.imageFeatures = '';
@@ -41,6 +42,7 @@ class SiteImages implements SiteImagesType {
         this.photographer = '';
         this.copyright = '';
     }
+    id: string;
     imageType: string;
     imageView: string;
     imageFeatures: string;

--- a/bcrhp/urls.py
+++ b/bcrhp/urls.py
@@ -36,10 +36,10 @@ class BCRegexPattern(RegexPattern):
         )
 
 
+common_url_resolver = re_path(r"^", include("bcgov_arches_common.urls"))
 bc_url_resolver = re_path((r"^"), include("arches.urls"))
 
-
-for pattern in bc_url_resolver.url_patterns:
+for pattern in bc_url_resolver.url_patterns + common_url_resolver.url_patterns:
     # print("Before: %s" % pattern.pattern)
     pattern.pattern = BCRegexPattern(pattern.pattern)
     # print("After: %s" % pattern.pattern)
@@ -119,11 +119,12 @@ urlpatterns = [
         bcrhp_export_results,
         name="export_results",
     ),
+    common_url_resolver,
     bc_url_resolver,
 ]
-# Ensure Arches core urls are superseded by project-level urls
-urlpatterns.append(path("", include("arches.urls")))
 
+# # Ensure Arches core urls are superseded by project-level urls
+# urlpatterns.append(path("", include("arches.urls")))
 
 # Adds URL pattern to serve media files during development
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
This PR applies the new `ConceptSelect` to `Image Type` and `Image View` to step 7 of the New Site workflow.

It also adds a UUID to the `Site Images` schema.