### PR TITLE
Implement PrimeVue Form component on Step6-Step10, solve merge conflicts

### DIFF
--- a/bcrhp/src/bcrhp/pages/steps/Step10_SupportingDocuments.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step10_SupportingDocuments.vue
@@ -36,7 +36,9 @@ const isValid = () => {
     let valid = true;
 
     for (const field of Object.values(fields) as Array<Ref>) {
-        valid = validateField(field?.value.$el as HTMLInputElement) && valid;
+        valid =
+            validateField({ name: field?.value.$el.id } as HTMLInputElement) &&
+            valid;
     }
     return valid;
 };

--- a/bcrhp/src/bcrhp/pages/steps/Step10_SupportingDocuments.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step10_SupportingDocuments.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useTemplateRef, inject, ref, onMounted } from 'vue';
+import { useTemplateRef, inject, ref } from 'vue';
 import type { Ref } from 'vue';
 
 import FieldSet from 'primevue/fieldset';
@@ -7,6 +7,8 @@ import InputText from 'primevue/inputtext';
 import FileUpload from 'primevue/fileupload';
 import RadioButton from 'primevue/radiobutton';
 import Editor from 'primevue/editor';
+import { Form, FormField } from '@primevue/forms';
+import type { FormFieldResolverOptions } from '@primevue/forms';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
 import { requiredHeritageSiteSchema } from '@/bcrhp/schema/HeritageSiteSchema.ts';
@@ -20,6 +22,7 @@ const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
 const ingredient = ref();
+
 const fields = {
     documentDescriptionField: useTemplateRef('documentDescriptionField'),
     submissionNotesField: useTemplateRef('submissionNotesField'),
@@ -38,38 +41,21 @@ const isValid = () => {
     return valid;
 };
 
-const valueUpdated = function (value: string | undefined) {
-    console.log(`valueUpdated: ${value}`);
+const resolver = function (e: FormFieldResolverOptions): Record<string, any> {
+    return validateField(e as FormFieldResolverOptions);
 };
 
-const valueChanged = function (event: Event) {
-    console.log(`valueChanged`);
-    validateField(event.target as HTMLInputElement);
-};
-
-const onFocusHandler = function (event: Event) {
-    console.log(`onFocusHandler ${event}`);
-    // (event.target as HTMLInputElement).classList.remove("p-invalid");
-};
-
-const onFocusOutHandler = function (event: Event) {
-    console.log(`onFocusOutHandler`);
-    validateField(event.target as HTMLInputElement);
-    // (event.target as HTMLInputElement).classList.remove("p-invalid");
-};
-
-const validateField = function (field: HTMLInputElement) {
-    console.log(`ID: ${field.id}`);
+const validateField = function (
+    event: FormFieldResolverOptions,
+): Record<string, any> {
     const key: keyof typeof HeritageSite =
-        field.id as keyof typeof HeritageSite;
+        event.name as keyof typeof HeritageSite;
     const fieldValidation = requiredHeritageSiteSchema.shape[key].safeParse(
         heritageSiteRef.value[key],
     );
     if (fieldValidation.success) {
-        field.classList.remove('p-invalid');
         errors.value[key] = [];
     } else {
-        field.classList.add('p-invalid');
         errors.value[key] = (
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
@@ -84,113 +70,120 @@ let validateFields = false;
 // This needs to be removed - added because ESLint was complaining. Need to figure out
 // configuration so API methods are not
 defineExpose({ isValid });
-
-onMounted(() => {});
 </script>
 <template>
-    <FieldSet
-        id="documentsFieldset"
-        legend="Supporting Documents"
+    <Form
+        ref="supportingDocumentsRef"
+        name="supportingDocumentsRef"
     >
-        <div class="flex flex-row gap-4">
-            <FileUpload
-                name="demo[]"
-                url="/api/upload"
-                :multiple="true"
-                accept="image/*"
-                :maxFileSize="1000000"
-                @upload="onAdvancedUpload()"
-            >
-                <template #empty>
-                    <span>Drag and drop files to here to upload.</span>
-                </template>
-            </FileUpload>
-            <div class="flex gap-4">
-                <div class="flex flex-col gap-2">
-                    <div class="flex items-center gap-2">Type</div>
-                    <div class="flex items-center">
-                        <RadioButton
-                            v-model="ingredient"
-                            inputId="documentType1"
-                            name="documentType"
-                            value="notificationLetter"
-                        />
-                        <label for="ingredient2">Notification Letter</label>
-                    </div>
-                    <div class="flex items-center">
-                        <RadioButton
-                            v-model="ingredient"
-                            inputId="documentType2"
-                            name="documentType"
-                            value="pdfMap"
-                        />
-                        <label for="ingredient3">PDF Map</label>
-                    </div>
-                    <div class="flex items-center">
-                        <RadioButton
-                            v-model="ingredient"
-                            inputId="documentType3"
-                            name="documentType"
-                            value="meetingMinutes"
-                        />
-                        <label for="ingredient4"
-                            >Bylaw / council meeting minutes</label
-                        >
-                    </div>
-                    <div class="flex items-center">
-                        <LabelledInput
-                            label="Document Description"
-                            hint="Provide short description of document content"
-                            input-name="documentDescription"
-                            :error-message="
-                                errors.documentDescription?.join(',')
-                            "
-                        >
-                            <div class="p-inputtext-fluid">
-                                <InputText
-                                    id="documentDescription"
-                                    ref="documentDescriptionField"
-                                    v-model="heritageSite.documentDescription"
-                                    aria-describedby="document-description-help"
-                                    aria-required="true"
-                                    fluid
-                                    @change="valueChanged"
-                                    @focus="onFocusHandler"
-                                    @focusout="onFocusOutHandler"
-                                    @update:model-value="valueUpdated"
-                                />
-                            </div>
-                        </LabelledInput>
+        <FieldSet
+            id="documentsFieldset"
+            legend="Supporting Documents"
+        >
+            <div class="flex flex-row gap-4">
+                <FileUpload
+                    name="demo[]"
+                    url="/api/upload"
+                    :multiple="true"
+                    accept="image/*"
+                    :maxFileSize="1000000"
+                    @upload="onAdvancedUpload()"
+                >
+                    <template #empty>
+                        <span>Drag and drop files to here to upload.</span>
+                    </template>
+                </FileUpload>
+                <div class="flex gap-4">
+                    <div class="flex flex-col gap-2">
+                        <div class="flex items-center gap-2">Type</div>
+                        <div class="flex items-center">
+                            <RadioButton
+                                v-model="ingredient"
+                                inputId="documentType1"
+                                name="documentType"
+                                value="notificationLetter"
+                            />
+                            <label for="ingredient2">Notification Letter</label>
+                        </div>
+                        <div class="flex items-center">
+                            <RadioButton
+                                v-model="ingredient"
+                                inputId="documentType2"
+                                name="documentType"
+                                value="pdfMap"
+                            />
+                            <label for="ingredient3">PDF Map</label>
+                        </div>
+                        <div class="flex items-center">
+                            <RadioButton
+                                v-model="ingredient"
+                                inputId="documentType3"
+                                name="documentType"
+                                value="meetingMinutes"
+                            />
+                            <label for="ingredient4"
+                                >Bylaw / council meeting minutes</label
+                            >
+                        </div>
+                        <div class="flex items-center">
+                            <FormField
+                                :resolver="resolver"
+                                name="documentDescription"
+                            >
+                                <LabelledInput
+                                    label="Document Description"
+                                    hint="Provide short description of document content"
+                                    input-name="documentDescription"
+                                    :error-message="
+                                        errors.documentDescription?.join(',')
+                                    "
+                                >
+                                    <div class="p-inputtext-fluid">
+                                        <InputText
+                                            id="documentDescription"
+                                            ref="documentDescriptionField"
+                                            v-model="
+                                                heritageSite.documentDescription
+                                            "
+                                            aria-describedby="document-description-help"
+                                            aria-required="true"
+                                            fluid
+                                        />
+                                    </div>
+                                </LabelledInput>
+                            </FormField>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-    </FieldSet>
-    <Fieldset
-        id="submissionNotesFieldset"
-        class="p-fieldset p-component mt-2"
-        legend="Submission Notes (Optional)"
-    >
-        <LabelledInput
-            input-name="submissionNotes"
-            hint="Enter any additional remarks about the site submission"
+        </FieldSet>
+        <Fieldset
+            id="submissionNotesFieldset"
+            class="p-fieldset p-component mt-2"
+            legend="Submission Notes (Optional)"
         >
-            <div class="p-inputtext-fluid">
-                <Editor
-                    id="submissionNotes"
-                    ref="submissionNotesField"
-                    v-model="heritageSite.submissionNotes"
-                    theme="snow"
-                    aria-describedby="submission-notes-help"
-                    fluid
-                    @editorChange="valueChanged"
-                    @focus="onFocusHandler"
-                    @blur="onFocusOutHandler"
-                    @update:content="valueUpdated"
-                />
-            </div>
-        </LabelledInput>
-    </Fieldset>
+            <FormField
+                :resolver="resolver"
+                name="submissionNotes"
+            >
+                <LabelledInput
+                    input-name="submissionNotes"
+                    hint="Enter any additional remarks about the site submission"
+                >
+                    <div class="p-inputtext-fluid">
+                        <Editor
+                            id="submissionNotes"
+                            ref="submissionNotesField"
+                            v-model="heritageSite.submissionNotes"
+                            theme="snow"
+                            aria-describedby="submission-notes-help"
+                            fluid
+                        />
+                    </div>
+                </LabelledInput>
+            </FormField>
+        </Fieldset>
+    </Form>
 </template>
 
 <style></style>

--- a/bcrhp/src/bcrhp/pages/steps/Step4_SiteNames.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step4_SiteNames.vue
@@ -45,8 +45,9 @@ const isValid = () => {
 
     for (const field of Object.values(fields) as Array<Ref>) {
         valid =
-            validateField(field?.value.$el as FormFieldResolverOptions) &&
-            valid;
+            validateField({
+                name: field?.value.$el.id,
+            } as FormFieldResolverOptions) && valid;
     }
     return valid;
 };

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -56,8 +56,9 @@ const isValid = () => {
 
     for (const field of Object.values(fields) as Array<Ref>) {
         valid =
-            validateField(field?.value.$el as FormFieldResolverOptions) &&
-            valid;
+            validateField({
+                name: field?.value.$el.id,
+            } as FormFieldResolverOptions) && valid;
     }
     return valid;
 };

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -134,6 +134,8 @@ onMounted(() => {
     >
         <FieldSet id="recognitionDetailsFieldset">
             <FormField
+                :validateOnValueUpdate="false"
+                :validateOnBlur="true"
                 :resolver="resolver"
                 name="designationDate"
             >
@@ -158,6 +160,8 @@ onMounted(() => {
                 </LabelledInput>
             </FormField>
             <FormField
+                :validateOnValueUpdate="false"
+                :validateOnBlur="true"
                 :resolver="resolver"
                 name="legislativeAct"
             >
@@ -206,6 +210,8 @@ onMounted(() => {
                 </LabelledInput>
             </FormField>
             <FormField
+                :validateOnValueUpdate="false"
+                :validateOnBlur="true"
                 :resolver="resolver"
                 name="referenceNumber"
             >

--- a/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
@@ -40,8 +40,9 @@ const isValid = () => {
 
     for (const field of Object.values(fields) as Array<Ref>) {
         valid =
-            validateField(field?.value.$el as FormFieldResolverOptions) &&
-            valid;
+            validateField({
+                name: field?.value.$el.id,
+            } as FormFieldResolverOptions) && valid;
     }
     return valid;
 };

--- a/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { useTemplateRef, inject, ref, onMounted } from 'vue';
+import { useTemplateRef, inject, ref } from 'vue';
 import type { Ref } from 'vue';
 
 import InputText from 'primevue/inputtext';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import Editor from 'primevue/editor';
+import { Form, FormField } from '@primevue/forms';
+import type { FormFieldResolverOptions } from '@primevue/forms';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
 import {
     StatementOfSignificance,
@@ -37,45 +39,29 @@ const isValid = () => {
     let valid = true;
 
     for (const field of Object.values(fields) as Array<Ref>) {
-        valid = validateField(field?.value.$el as HTMLInputElement) && valid;
+        valid =
+            validateField(field?.value.$el as FormFieldResolverOptions) &&
+            valid;
     }
     return valid;
 };
 
-const valueUpdated = function (value: string | undefined) {
-    console.log(`valueUpdated: ${value}`);
+const resolver = function (e: FormFieldResolverOptions): Record<string, any> {
+    return validateField(e as FormFieldResolverOptions);
 };
 
-const valueChanged = function (event: Event) {
-    console.log(`valueChanged`);
-    validateField(event.target as HTMLInputElement);
-};
-
-const onFocusHandler = function (event: Event) {
-    console.log(`onFocusHandler ${event}`);
-    // (event.target as HTMLInputElement).classList.remove("p-invalid");
-};
-
-const onFocusOutHandler = function (event: Event) {
-    console.log(`onFocusOutHandler`);
-    validateField(event.target as HTMLInputElement);
-    // (event.target as HTMLInputElement).classList.remove("p-invalid");
-};
-
-const validateField = function (field: HTMLInputElement) {
-    console.log(`ID: ${field}`);
-
+const validateField = function (
+    event: FormFieldResolverOptions,
+): Record<string, any> {
     const key: keyof typeof StatementOfSignificance =
-        field.id as keyof typeof StatementOfSignificance;
+        event.name as keyof typeof StatementOfSignificance;
     const fieldValidation = requiredStatementOfSignificanceSchema.shape[
         key
     ].safeParse(heritageSiteRef.value.statementOfSignificance[key]);
 
     if (fieldValidation.success) {
-        field.classList.remove('p-invalid');
         errors.value[key] = [];
     } else {
-        field.classList.add('p-invalid');
         errors.value[key] = (
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
@@ -89,108 +75,122 @@ let validateFields = false;
 // This needs to be removed - added because ESLint was complaining. Need to figure out
 // configuration so API methods are not
 defineExpose({ isValid });
-
-onMounted(() => {});
 </script>
 <template>
-    <div>
-        <LabelledInput
-            label="Description"
-            hint="Briefly describe the site as it exists today, where it is located (including province) and its physical extent and contributing resources"
-            input-name="description"
-            :error-message="errors.description?.join(',')"
-            :required="true"
-        >
-            <div class="p-inputtext-fluid">
-                <Editor
-                    id="description"
-                    ref="descriptionField"
-                    v-model="heritageSite.statementOfSignificance.description"
-                    theme="snow"
-                    aria-describedby="description-help"
-                    aria-required="true"
-                    fluid
-                    @editorChange="valueChanged"
-                    @focus="onFocusHandler"
-                    @blur="onFocusOutHandler"
-                    @update:content="valueUpdated"
-                />
-            </div>
-        </LabelledInput>
-        <LabelledInput
-            label="Heritage Value"
-            hint="Describe why the place is valued by the community and identify which heritage values the official recognition is based on"
-            input-name="heritageValue"
-            :error-message="errors.heritageValue?.join(',')"
-            :required="true"
-        >
-            <div class="p-inputtext-fluid">
-                <Editor
-                    id="heritageValue"
-                    ref="heritageValueField"
-                    v-model="heritageSite.statementOfSignificance.heritageValue"
-                    theme="snow"
-                    aria-describedby="heritage-value-help"
-                    aria-required="true"
-                    fluid
-                    @editorChange="valueChanged"
-                    @focus="onFocusHandler"
-                    @blur="onFocusOutHandler"
-                    @update:content="valueUpdated"
-                />
-            </div>
-        </LabelledInput>
-        <LabelledInput
-            label="Character-Defining Elements"
-            hint="List the key features of the heritage site that contribute to its heritage value in bullet-point format"
-            input-name="definingElements"
-            :error-message="errors.definingElements?.join(',')"
-            :required="true"
-        >
-            <div class="p-inputtext-fluid">
-                <Editor
-                    id="definingElements"
-                    ref="definingElementsField"
-                    v-model="
-                        heritageSite.statementOfSignificance.definingElements
-                    "
-                    theme="snow"
-                    aria-describedby="defining-elements-help"
-                    aria-required="true"
-                    fluid
-                    @editorChange="valueChanged"
-                    @focus="onFocusHandler"
-                    @blur="onFocusOutHandler"
-                    @update:content="valueUpdated"
-                />
-            </div>
-        </LabelledInput>
-        <LabelledInput
-            label="Document Location"
-            hint="Enter the government or department name where the original document was created"
-            input-name="documentLocation"
-            :error-message="errors.documentLocation?.join(',')"
-            :required="true"
-        >
-            <div>
-                <InputText
-                    id="documentLocation"
-                    ref="documentLocationField"
-                    v-model="
-                        heritageSite.statementOfSignificance.documentLocation
-                    "
-                    aria-describedby="document-location-help"
-                    aria-required="true"
-                    fluid
-                    class="inline-block"
-                    @change="valueChanged"
-                    @focus="onFocusHandler"
-                    @focusout="onFocusOutHandler"
-                    @update:model-value="valueUpdated"
-                />
-            </div>
-        </LabelledInput>
-    </div>
+    <Form
+        ref="siteNamesRef"
+        name="siteNamesRef"
+    >
+        <div>
+            <FormField
+                :resolver="resolver"
+                name="description"
+            >
+                <LabelledInput
+                    label="Description"
+                    hint="Briefly describe the site as it exists today, where it is located (including province) and its physical extent and contributing resources"
+                    input-name="description"
+                    :error-message="errors.description?.join(',')"
+                    :required="true"
+                >
+                    <div class="p-inputtext-fluid">
+                        <Editor
+                            id="description"
+                            ref="descriptionField"
+                            v-model="
+                                heritageSite.statementOfSignificance.description
+                            "
+                            theme="snow"
+                            aria-describedby="description-help"
+                            aria-required="true"
+                            fluid
+                        />
+                    </div>
+                </LabelledInput>
+            </FormField>
+            <FormField
+                :resolver="resolver"
+                name="heritageValue"
+            >
+                <LabelledInput
+                    label="Heritage Value"
+                    hint="Describe why the place is valued by the community and identify which heritage values the official recognition is based on"
+                    input-name="heritageValue"
+                    :error-message="errors.heritageValue?.join(',')"
+                    :required="true"
+                >
+                    <div class="p-inputtext-fluid">
+                        <Editor
+                            id="heritageValue"
+                            ref="heritageValueField"
+                            v-model="
+                                heritageSite.statementOfSignificance
+                                    .heritageValue
+                            "
+                            theme="snow"
+                            aria-describedby="heritage-value-help"
+                            aria-required="true"
+                            fluid
+                        />
+                    </div>
+                </LabelledInput>
+            </FormField>
+            <FormField
+                :resolver="resolver"
+                name="definingElements"
+            >
+                <LabelledInput
+                    label="Character-Defining Elements"
+                    hint="List the key features of the heritage site that contribute to its heritage value in bullet-point format"
+                    input-name="definingElements"
+                    :error-message="errors.definingElements?.join(',')"
+                    :required="true"
+                >
+                    <div class="p-inputtext-fluid">
+                        <Editor
+                            id="definingElements"
+                            ref="definingElementsField"
+                            v-model="
+                                heritageSite.statementOfSignificance
+                                    .definingElements
+                            "
+                            theme="snow"
+                            aria-describedby="defining-elements-help"
+                            aria-required="true"
+                            fluid
+                        />
+                    </div>
+                </LabelledInput>
+            </FormField>
+            <FormField
+                :resolver="resolver"
+                name="documentLocation"
+            >
+                <LabelledInput
+                    label="Document Location"
+                    hint="Enter the government or department name where the original document was created"
+                    input-name="documentLocation"
+                    :error-message="errors.documentLocation?.join(',')"
+                    :required="true"
+                >
+                    <div>
+                        <InputText
+                            id="documentLocation"
+                            ref="documentLocationField"
+                            v-model="
+                                heritageSite.statementOfSignificance
+                                    .documentLocation
+                            "
+                            aria-describedby="document-location-help"
+                            aria-required="true"
+                            fluid
+                            class="inline-block"
+                        />
+                    </div>
+                </LabelledInput>
+            </FormField>
+        </div>
+    </Form>
 </template>
 
 <style>

--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -5,7 +5,8 @@ import type { Ref } from 'vue';
 import InputText from 'primevue/inputtext';
 import Editor from 'primevue/editor';
 import DatePicker from 'primevue/datepicker';
-
+import { Form, FormField } from '@primevue/forms';
+import type { FormFieldResolverOptions } from '@primevue/forms';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import ConceptSelect from '@/bcgov_arches_common/components/ConceptSelect/ConceptSelect.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
@@ -46,44 +47,28 @@ const isValid = () => {
     let valid = true;
 
     for (const field of Object.values(fields) as Array<Ref>) {
-        valid = validateField(field?.value.$el as HTMLInputElement) && valid;
+        valid =
+            validateField(field?.value.$el as FormFieldResolverOptions) &&
+            valid;
     }
     return valid;
 };
 
-const valueUpdated = function (value: string | undefined) {
-    console.log(`valueUpdated: ${value}`);
+const resolver = function (e: FormFieldResolverOptions): Record<string, any> {
+    return validateField(e as FormFieldResolverOptions);
 };
 
-const valueChanged = function (event: Event) {
-    console.log(`valueChanged`);
-    validateField(event.target as HTMLInputElement);
-};
-
-const onFocusHandler = function (event: Event) {
-    console.log(`onFocusHandler ${event}`);
-    // (event.target as HTMLInputElement).classList.remove("p-invalid");
-};
-
-const onFocusOutHandler = function (event: Event) {
-    console.log(`onFocusOutHandler`);
-    validateField(event.target as HTMLInputElement);
-    // (event.target as HTMLInputElement).classList.remove("p-invalid");
-};
-
-const validateField = function (field: HTMLInputElement) {
-    console.log(`ID: ${field.id}`);
-
-    const key: keyof typeof SiteImages = field.id as keyof typeof SiteImages;
+const validateField = function (
+    event: FormFieldResolverOptions,
+): Record<string, any> {
+    const key: keyof typeof SiteImages = event.name as keyof typeof SiteImages;
     const fieldValidation = requiredSiteImagesSchema.shape[key].safeParse(
         currentSiteImage.value[key],
     );
 
     if (fieldValidation.success) {
-        field.classList.remove('p-invalid');
         errors.value[key] = [];
     } else {
-        field.classList.add('p-invalid');
         errors.value[key] = (
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
@@ -111,160 +96,184 @@ const updateImageType = function (
 onMounted(() => {});
 </script>
 <template>
-    <div class="flex flex-row">
-        <FileUpload
-            name="fileUpload"
-            url="/api/upload"
-            :multiple="true"
-            accept="image/*"
-            :maxFileSize="1000000"
-            @upload="onImageUpload"
+    <Form
+        ref="siteImageRef"
+        name="siteImageRef"
+    >
+        <div class="flex flex-row">
+            <FileUpload
+                name="fileUpload"
+                url="/api/upload"
+                :multiple="true"
+                accept="image/*"
+                :maxFileSize="1000000"
+                @upload="onImageUpload"
+            >
+                <template #empty>
+                    <span>Drag and drop files to here to upload.</span>
+                </template>
+            </FileUpload>
+            <FormField
+                :resolver="resolver"
+                name="imageType"
+            >
+                <LabelledInput
+                    label="Image Type"
+                    hint="Select Historical or Contemporary image type"
+                    input-name="imageType"
+                    :error-message="errors.imageType?.join(',')"
+                    :required="true"
+                >
+                    <div class="p-inputtext-fluid">
+                        <ConceptSelect
+                            id="imageType"
+                            ref="imageTypeField"
+                            graph-slug="heritage_site"
+                            node-alias="image_type"
+                            model-value="currentSiteImage.imageType"
+                            placeholder="Select an Image Type"
+                            @value-updated="updateImageType"
+                        />
+                    </div>
+                </LabelledInput>
+            </FormField>
+            <FormField
+                :resolver="resolver"
+                name="imageView"
+            >
+                <LabelledInput
+                    label="Image View"
+                    hint="Select the view that best describes the image"
+                    input-name="imageView"
+                    :error-message="errors.imageView?.join(',')"
+                    :required="true"
+                >
+                    <div class="p-inputtext-fluid">
+                        <ConceptSelect
+                            id="imageView"
+                            ref="imageViewField"
+                            graph-slug="heritage_site"
+                            node-alias="image_view"
+                            model-value="currentSiteImage.imageView"
+                            placeholder="Select an Image View"
+                            @value-updated="updateImageType"
+                        />
+                    </div>
+                </LabelledInput>
+            </FormField>
+        </div>
+        <FormField
+            :resolver="resolver"
+            name="imageFeatures"
         >
-            <template #empty>
-                <span>Drag and drop files to here to upload.</span>
-            </template>
-        </FileUpload>
-        <LabelledInput
-            label="Image Type"
-            hint="Select Historical or Contemporary image type"
-            input-name="commonName"
-            :error-message="errors.imageType?.join(',')"
-            :required="true"
+            <LabelledInput
+                label="Image Features (Optional)"
+                hint="Enter the features or subjects depicted by the photograph"
+                input-name="imageFeatures"
+                :error-message="errors.imageFeatures?.join(',')"
+            >
+                <div>
+                    <InputText
+                        id="imageFeatures"
+                        ref="imageFeaturesField"
+                        v-model="heritageSite.siteImages.imageFeatures"
+                        aria-describedby="image-features-help"
+                        fluid
+                        class="inline-block"
+                    />
+                </div>
+            </LabelledInput>
+        </FormField>
+        <FormField
+            :resolver="resolver"
+            name="imageDate"
         >
-            <div class="p-inputtext-fluid">
-                <ConceptSelect
-                    id="imageType"
-                    ref="imageTypeField"
-                    graph-slug="heritage_site"
-                    node-alias="image_type"
-                    model-value="currentSiteImage.imageType"
-                    placeholder="Select an Image Type"
-                    @value-updated="updateImageType"
+            <LabelledInput
+                label="Image Date"
+                hint="Date the image was created"
+                input-name="imageDate"
+                :error-message="errors.imageDate?.join(',')"
+                :required="true"
+            >
+                <DatePicker
+                    id="imageDate"
+                    ref="imageDateField"
+                    v-model="heritageSite.siteImages.imageDate"
+                    show-icon
+                    aria-describedby="image-date-help"
+                    aria-required="true"
                 />
-            </div>
-        </LabelledInput>
-        <LabelledInput
-            label="Image View"
-            hint="Select the view that best describes the image"
-            input-name="imageView"
-            :error-message="errors.imageView?.join(',')"
-            :required="true"
+            </LabelledInput>
+        </FormField>
+        <FormField
+            :resolver="resolver"
+            name="imageDescription"
         >
-            <div class="p-inputtext-fluid">
-                <ConceptSelect
-                    id="imageView"
-                    ref="imageViewField"
-                    graph-slug="heritage_site"
-                    node-alias="image_view"
-                    model-value="currentSiteImage.imageView"
-                    placeholder="Select an Image View"
-                    @value-updated="updateImageType"
-                />
-            </div>
-        </LabelledInput>
-    </div>
-    <LabelledInput
-        label="Image Features (Optional)"
-        hint="Enter the features or subjects depicted by the photograph"
-        input-name="imageFeatures"
-        :error-message="errors.imageFeatures?.join(',')"
-    >
-        <div>
-            <InputText
-                id="imageFeatures"
-                ref="imageFeaturesField"
-                v-model="heritageSite.siteImages.imageFeatures"
-                aria-describedby="image-features-help"
-                fluid
-                class="inline-block"
-                @change="valueChanged"
-                @focus="onFocusHandler"
-                @focusout="onFocusOutHandler"
-                @update:model-value="valueUpdated"
-            />
-        </div>
-    </LabelledInput>
-    <LabelledInput
-        label="Image Date"
-        hint="Date the image was created"
-        input-name="imageDate"
-        :error-message="errors.imageDate?.join(',')"
-        :required="true"
-    >
-        <DatePicker
-            id="imageDate"
-            ref="imageDateField"
-            v-model="heritageSite.siteImages.imageDate"
-            show-icon
-            aria-describedby="image-date-help"
-            aria-required="true"
-        />
-    </LabelledInput>
-    <LabelledInput
-        label="Image Description"
-        hint="Summarize the image content including site address and site name. Include additional information that does not fit fields above"
-        input-name="definingElements"
-        :error-message="errors.imageDescription?.join(',')"
-        :required="true"
-    >
-        <div class="p-inputtext-fluid">
-            <Editor
-                id="imageDescription"
-                ref="imageDescriptionField"
-                v-model="heritageSite.siteImages.imageDescription"
-                theme="snow"
-                aria-describedby="image-description-help"
-                aria-required="true"
-                fluid
-                @editorChange="valueChanged"
-                @focus="onFocusHandler"
-                @blur="onFocusOutHandler"
-                @update:content="valueUpdated"
-            />
-        </div>
-    </LabelledInput>
-    <LabelledInput
-        label="Photographer (Optional)"
-        hint="Enter the name of the photographer"
-        input-name="photographer"
-        :error-message="errors.photographer?.join(',')"
-    >
-        <div>
-            <InputText
-                id="photographer"
-                ref="photographerField"
-                v-model="heritageSite.siteImages.photographer"
-                aria-describedby="image-features-help"
-                aria-required="true"
-                fluid
-                class="inline-block"
-                @change="valueChanged"
-                @focus="onFocusHandler"
-                @focusout="onFocusOutHandler"
-                @update:model-value="valueUpdated"
-            />
-        </div>
-    </LabelledInput>
-    <LabelledInput
-        label="Copyright (Optional)"
-        hint="Enter the name of the copyright holder for the image"
-        input-name="copyright"
-        :error-message="errors.copyright?.join(',')"
-    >
-        <div>
-            <InputText
-                id="copyright"
-                ref="copyrightField"
-                v-model="heritageSite.siteImages.copyright"
-                aria-describedby="copyright-help"
-                aria-required="true"
-                fluid
-                class="inline-block"
-                @change="valueChanged"
-                @focus="onFocusHandler"
-                @focusout="onFocusOutHandler"
-                @update:model-value="valueUpdated"
-            />
-        </div>
-    </LabelledInput>
+            <LabelledInput
+                label="Image Description"
+                hint="Summarize the image content including site address and site name. Include additional information that does not fit fields above"
+                input-name="definingElements"
+                :error-message="errors.imageDescription?.join(',')"
+                :required="true"
+            >
+                <div class="p-inputtext-fluid">
+                    <Editor
+                        id="imageDescription"
+                        ref="imageDescriptionField"
+                        v-model="heritageSite.siteImages.imageDescription"
+                        theme="snow"
+                        aria-describedby="image-description-help"
+                        aria-required="true"
+                        fluid
+                    />
+                </div>
+            </LabelledInput>
+        </FormField>
+        <FormField
+            :resolver="resolver"
+            name="photographer"
+        >
+            <LabelledInput
+                label="Photographer (Optional)"
+                hint="Enter the name of the photographer"
+                input-name="photographer"
+                :error-message="errors.photographer?.join(',')"
+            >
+                <div>
+                    <InputText
+                        id="photographer"
+                        ref="photographerField"
+                        v-model="heritageSite.siteImages.photographer"
+                        aria-describedby="image-features-help"
+                        aria-required="true"
+                        fluid
+                        class="inline-block"
+                    />
+                </div>
+            </LabelledInput>
+        </FormField>
+        <FormField
+            :resolver="resolver"
+            name="copyright"
+        >
+            <LabelledInput
+                label="Copyright (Optional)"
+                hint="Enter the name of the copyright holder for the image"
+                input-name="copyright"
+                :error-message="errors.copyright?.join(',')"
+            >
+                <div>
+                    <InputText
+                        id="copyright"
+                        ref="copyrightField"
+                        v-model="heritageSite.siteImages.copyright"
+                        aria-describedby="copyright-help"
+                        aria-required="true"
+                        fluid
+                        class="inline-block"
+                    />
+                </div>
+            </LabelledInput>
+        </FormField>
+    </Form>
 </template>

--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -49,9 +49,16 @@ const isValid = () => {
     let valid = true;
 
     for (const field of Object.values(fields) as Array<Ref>) {
+        let id = '';
+        // Workaround needed for back button error bug. Id gets set to pv_id for unknown reason
+        // Only in this component
+        if (field?.value.$el.id.startsWith('pv_id_')) {
+            id = 'imageType';
+        } else {
+            id = field?.value.$el.id;
+        }
         valid =
-            validateField(field?.value.$el as FormFieldResolverOptions) &&
-            valid;
+            validateField({ name: id } as FormFieldResolverOptions) && valid;
     }
     return valid;
 };

--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -20,6 +20,8 @@ import type { ZodError } from 'zod';
 const heritageSite: typeof HeritageSite = inject(
     'heritageSite',
 ) as typeof HeritageSite;
+const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
+
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
 
@@ -63,7 +65,7 @@ const validateField = function (
 ): Record<string, any> {
     const key: keyof typeof SiteImages = event.name as keyof typeof SiteImages;
     const fieldValidation = requiredSiteImagesSchema.shape[key].safeParse(
-        currentSiteImage.value[key],
+        heritageSiteRef.value.siteImages[key],
     );
 
     if (fieldValidation.success) {

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -69,7 +69,10 @@ const isValid = () => {
     let valid = true;
 
     for (const field of Object.values(fields) as Array<Ref>) {
-        valid = resolver(field?.value.$el as FormFieldResolverOptions) && valid;
+        valid =
+            resolver({
+                name: field?.value.$el.id,
+            } as FormFieldResolverOptions) && valid;
     }
     return valid;
 };

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -128,7 +128,9 @@ const validateHeritageClassField = function (
     const key: keyof typeof HeritageClass =
         event.name as keyof typeof HeritageClass;
     const fieldValidation = requiredHeritageClassSchema.shape[key].safeParse(
-        currentHeritageClass.value[key],
+        key === 'contributingResources'
+            ? parseInt(currentHeritageClass.value[key])
+            : currentHeritageClass.value[key],
     );
     if (fieldValidation.success) {
         errors.value[key] = [];

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { inject, ref, onMounted } from 'vue';
+import { useTemplateRef, inject, ref, onMounted } from 'vue';
 import type { Ref } from 'vue';
 
 import FieldSet from 'primevue/fieldset';
 import Button from 'primevue/button';
-import RadioButton from 'primevue/radiobutton';
-import Select from 'primevue/select';
+import { Form, FormField } from '@primevue/forms';
+import type { FormFieldResolverOptions } from '@primevue/forms';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePlaceholder/MultiValuePlaceholder.vue';
 import ConceptSelect from '@/bcgov_arches_common/components/ConceptSelect/ConceptSelect.vue';
@@ -43,24 +43,47 @@ const addContributingResourcesDisabled = ref(false);
 const addOtherFunctionCategoryDisabled = ref(false);
 const addOtherHeritageSiteDisabled = ref(false);
 
-const updateSelectValue = function (
-    newValue: string,
-    selectField: typeof RadioButton | typeof ConceptSelect,
-) {
-    console.log(`New value ${newValue}`);
-    validateField(selectField);
+// const updateSelectValue = function (
+//     newValue: string,
+//     selectField: typeof RadioButton | typeof ConceptSelect,
+// ) {
+//     console.log(`New value ${newValue}`);
+//     validateField(selectField);
+// };
+
+const fields = {
+    numberOfResourcesField: useTemplateRef('numberOfResourcesField'),
+    heritageCategoryField: useTemplateRef('heritageCategoryField'),
+    ownershipField: useTemplateRef('ownershipField'),
+    functionCategoryField: useTemplateRef('functionCategoryField'),
+    functionCategoryTypeRef: useTemplateRef('functionCategoryTypeRef'),
+    heritageThemeField: useTemplateRef('heritageThemeField'),
 };
 
-const validateField = function (
-    inputField: typeof Select | typeof RadioButton,
-) {
-    if (Object.hasOwn(currentHeritageClass, inputField?.inputId)) {
-        validateHeritageClassField(inputField as HTMLInputElement);
-    } else if (Object.hasOwn(currentHeritageFunction, inputField?.inputId)) {
-        validateHeritageFunctionField(inputField as HTMLInputElement);
-    } else if (Object.hasOwn(currentHeritageTheme, inputField?.inputId)) {
-        validateHeritageThemeField(inputField as HTMLInputElement);
+const isValid = () => {
+    // We don't want to validate fields the first time we show the step
+    if (!validateFields) {
+        validateFields = true;
+        return true;
     }
+    let valid = true;
+
+    for (const field of Object.values(fields) as Array<Ref>) {
+        valid = resolver(field?.value.$el as FormFieldResolverOptions) && valid;
+    }
+    return valid;
+};
+
+const resolver = function (e: FormFieldResolverOptions): Record<string, any> {
+    if (Object.hasOwn(currentHeritageClass.value, e.name ?? '')) {
+        return validateHeritageClassField(e as FormFieldResolverOptions);
+    } else if (Object.hasOwn(currentHeritageFunction.value, e.name ?? '')) {
+        return validateHeritageFunctionField(e as FormFieldResolverOptions);
+    } else if (Object.hasOwn(currentHeritageTheme.value, e.name ?? '')) {
+        return validateHeritageThemeField(e as FormFieldResolverOptions);
+    }
+
+    return {};
 };
 
 const updateAddHeritageClassCategory = function () {
@@ -81,18 +104,17 @@ const updateAddOtherHeritageSite = function () {
         heritageSiteRef.value.siteClassification.heritageThemes.length > 4;
 };
 
-const validateSiteClassificationFields = function (field: HTMLInputElement) {
-    console.log(`ID: ${field.id}`);
+const validateSiteClassificationFields = function (
+    event: FormFieldResolverOptions,
+): Record<string, any> {
     const key: keyof typeof SiteClassification =
-        field.id as keyof typeof SiteClassification;
+        event.name as keyof typeof SiteClassification;
     const fieldValidation = requiredSiteClassificationSchema.shape[
         key
     ].safeParse(heritageSiteRef.value[key]);
     if (fieldValidation.success) {
-        field.classList.remove('p-invalid');
         errors.value[key] = [];
     } else {
-        field.classList.add('p-invalid');
         errors.value[key] = (
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
@@ -100,18 +122,17 @@ const validateSiteClassificationFields = function (field: HTMLInputElement) {
     return fieldValidation.success;
 };
 
-const validateHeritageClassField = function (field: HTMLInputElement) {
-    console.log(`ID: ${field.id}`);
+const validateHeritageClassField = function (
+    event: FormFieldResolverOptions,
+): Record<string, any> {
     const key: keyof typeof HeritageClass =
-        field.id as keyof typeof HeritageClass;
+        event.name as keyof typeof HeritageClass;
     const fieldValidation = requiredHeritageClassSchema.shape[key].safeParse(
-        currentHeritageClass.value[field.id],
+        currentHeritageClass.value[key],
     );
     if (fieldValidation.success) {
-        field.classList.remove('p-invalid');
         errors.value[key] = [];
     } else {
-        field.classList.add('p-invalid');
         errors.value[key] = (
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
@@ -119,18 +140,17 @@ const validateHeritageClassField = function (field: HTMLInputElement) {
     return fieldValidation.success;
 };
 
-const validateHeritageFunctionField = function (field: HTMLInputElement) {
-    console.log(`ID: ${field.id}`);
+const validateHeritageFunctionField = function (
+    event: FormFieldResolverOptions,
+): Record<string, any> {
     const key: keyof typeof HeritageFunction =
-        field.id as keyof typeof HeritageFunction;
+        event.name as keyof typeof HeritageFunction;
     const fieldValidation = requiredHeritageFunctionSchema.shape[key].safeParse(
-        currentHeritageFunction.value[field.id],
+        currentHeritageFunction.value[key],
     );
     if (fieldValidation.success) {
-        field.classList.remove('p-invalid');
         errors.value[key] = [];
     } else {
-        field.classList.add('p-invalid');
         errors.value[key] = (
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
@@ -138,18 +158,17 @@ const validateHeritageFunctionField = function (field: HTMLInputElement) {
     return fieldValidation.success;
 };
 
-const validateHeritageThemeField = function (field: HTMLInputElement) {
-    console.log(`ID: ${field.id}`);
+const validateHeritageThemeField = function (
+    event: FormFieldResolverOptions,
+): Record<string, any> {
     const key: keyof typeof HeritageTheme =
-        field.id as keyof typeof HeritageTheme;
+        event.name as keyof typeof HeritageTheme;
     const fieldValidation = requiredHeritageThemeSchema.shape[key].safeParse(
-        currentHeritageTheme.value[field.id],
+        currentHeritageTheme.value[key],
     );
     if (fieldValidation.success) {
-        field.classList.remove('p-invalid');
         errors.value[key] = [];
     } else {
-        field.classList.add('p-invalid');
         errors.value[key] = (
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
@@ -206,6 +225,12 @@ const deleteHeritageThemeCallback = function (index: number) {
     updateAddOtherHeritageSite();
 };
 
+let validateFields = false;
+
+// This needs to be removed - added because ESLint was complaining. Need to figure out
+// configuration so API methods are not
+defineExpose({ isValid });
+
 onMounted(() => {
     heritageSiteRef.value.siteClassification.heritageClasses = heritageClasses;
     heritageSiteRef.value.siteClassification.heritageFunctions =
@@ -218,177 +243,209 @@ onMounted(() => {
 });
 </script>
 <template>
-    <FieldSet
-        id="heritageDetailsFieldset"
-        legend="Heritage Class"
+    <Form
+        ref="siteClassificationRef"
+        name="siteClassificationRef"
     >
-        <LabelledInput
-            label="Number of Contributing Resources"
-            input-name="contributingResources"
-            :error-message="errors.contributingResources?.join(',')"
-            :required="true"
+        <FieldSet
+            id="heritageDetailsFieldset"
+            legend="Heritage Class"
         >
-            <div>
-                <InputText
-                    id="contributingResources"
-                    ref="numberOfResourcesField"
-                    v-model="currentHeritageClass.contributingResources"
-                    aria-describedby="contributing-resources-help"
-                    aria-required="true"
-                    fluid
-                    class="inline-block"
-                />
-                <Button
-                    id="saveHeritageClass"
-                    :disabled="addContributingResourcesDisabled"
-                    :aria-disabled="addContributingResourcesDisabled"
-                    label="Add"
-                    class="inline-block"
-                    @click="saveHeritageClass"
-                ></Button>
-            </div>
-        </LabelledInput>
-        <div class="flex flex-col">
-            <p class="mb-1">Heritage Category</p>
-            <div class="flex flex-col">
-                <ConceptRadioButtons
-                    id="heritageCategory"
-                    ref="heritageCategoryField"
-                    v-model="currentHeritageClass.heritageCategory"
-                    graph-slug="heritage_site"
-                    node-alias="heritage_category"
-                    group-direction="column"
-                    @value-updated="updateSelectValue"
-                />
-            </div>
-            <p class="mb-1">Ownership</p>
-            <div class="flex flex-col">
-                <ConceptRadioButtons
-                    id="ownership"
-                    ref="ownershipField"
-                    v-model="currentHeritageClass.ownership"
-                    graph-slug="heritage_site"
-                    node-alias="ownership"
-                    group-direction="column"
-                    @value-updated="updateSelectValue"
-                />
-            </div>
-        </div>
-        <MultiValuePlaceholder
-            v-slot="slotProps"
-            :showDeleteButton="true"
-            :displayValues="heritageClasses"
-            label="Heritage Class/Classes"
-            :deleteCallback="deleteContributingResourcesCallback"
-        >
-            <div
-                v-for="slot in slotProps"
-                :key="slot"
-                class="parent value"
+            <FormField
+                :resolver="resolver"
+                name="contributingResources"
             >
-                {{ slot.heritageCategory }} {{ slot.ownership }}
-                {{ slot.contributingResources }}
-            </div>
-        </MultiValuePlaceholder>
-    </FieldSet>
-    <Fieldset
-        id="heritageFunctionFieldset"
-        class="p-fieldset p-component mt-2"
-        legend="Heritage Function"
-    >
-        <LabelledInput
-            label="Function Category"
-            input-name="heritageTheme"
-            :error-message="errors.functionCategories?.join(',')"
-            :required="true"
-        >
-            <div class="p-inputtext-fluid flex flex-row">
-                <ConceptSelect
-                    id="functionCategory"
-                    ref="functionCategoryField"
-                    v-model="currentHeritageFunction.functionCategory"
-                    graph-slug="heritage_site"
-                    node-alias="function_category"
-                    @value-updated="updateSelectValue"
-                />
-                <div class="inline-block">
-                    <ConceptRadioButtons
-                        id="functionCategoryType"
-                        ref="functionCategoryTypeRef"
-                        v-model="currentHeritageFunction.functionCategoryType"
-                        graph-slug="heritage_site"
-                        node-alias="functional_category"
-                        group-direction="column"
-                        @value-updated="updateSelectValue"
-                    />
+                <LabelledInput
+                    label="Number of Contributing Resources"
+                    input-name="contributingResources"
+                    :error-message="errors.contributingResources?.join(',')"
+                    :required="true"
+                >
+                    <div>
+                        <InputText
+                            id="contributingResources"
+                            ref="numberOfResourcesField"
+                            v-model="currentHeritageClass.contributingResources"
+                            aria-describedby="contributing-resources-help"
+                            aria-required="true"
+                            fluid
+                            class="inline-block"
+                        />
+                        <Button
+                            id="saveHeritageClass"
+                            :disabled="addContributingResourcesDisabled"
+                            :aria-disabled="addContributingResourcesDisabled"
+                            label="Add"
+                            class="inline-block"
+                            @click="saveHeritageClass"
+                        ></Button>
+                    </div>
+                </LabelledInput>
+            </FormField>
+            <div class="flex flex-col">
+                <p class="mb-1">Heritage Category</p>
+                <div class="flex flex-col">
+                    <FormField
+                        :resolver="resolver"
+                        name="heritageCategory"
+                    >
+                        <ConceptRadioButtons
+                            id="heritageCategory"
+                            ref="heritageCategoryField"
+                            v-model="currentHeritageClass.heritageCategory"
+                            graph-slug="heritage_site"
+                            node-alias="heritage_category"
+                            group-direction="column"
+                        />
+                    </FormField>
+                </div>
+                <p class="mb-1">Ownership</p>
+                <div class="flex flex-col">
+                    <FormField
+                        :resolver="resolver"
+                        name="ownership"
+                    >
+                        <ConceptRadioButtons
+                            id="ownership"
+                            ref="ownershipField"
+                            v-model="currentHeritageClass.ownership"
+                            graph-slug="heritage_site"
+                            node-alias="ownership"
+                            group-direction="column"
+                        />
+                    </FormField>
                 </div>
             </div>
-            <Button
-                id="saveFunctionCategory"
-                label="Add"
-                class="inline-block"
-                :disabled="addOtherFunctionCategoryDisabled"
-                :aria-disabled="addOtherFunctionCategoryDisabled"
-                @click="saveFunctionCategory"
-            ></Button>
-        </LabelledInput>
-        <MultiValuePlaceholder
-            v-slot="slotProps"
-            :showDeleteButton="true"
-            :displayValues="heritageFunctions"
-            label="Category/Categories"
-            :deleteCallback="deleteFunctionCategoryCallback"
-        >
-            <div
-                v-for="slot in slotProps"
-                :key="slot"
-                class="parent value"
+            <MultiValuePlaceholder
+                v-slot="slotProps"
+                :showDeleteButton="true"
+                :displayValues="heritageClasses"
+                label="Heritage Class/Classes"
+                :deleteCallback="deleteContributingResourcesCallback"
             >
-                {{ slot.functionCategory }}
-                {{ slot.functionCategoryType }}
-            </div>
-        </MultiValuePlaceholder>
-    </Fieldset>
-    <Fieldset
-        id="heritageThemeFieldset"
-        class="p-fieldset p-component mt-2"
-        legend="Heritage Theme"
-    >
-        <LabelledInput
-            label="Heritage Theme"
-            input-name="heritageTheme"
-            :error-message="errors.heritageThemes?.join(',')"
-            :required="true"
+                <div
+                    v-for="slot in slotProps"
+                    :key="slot"
+                    class="parent value"
+                >
+                    {{ slot.heritageCategory }} {{ slot.ownership }}
+                    {{ slot.contributingResources }}
+                </div>
+            </MultiValuePlaceholder>
+        </FieldSet>
+        <Fieldset
+            id="heritageFunctionFieldset"
+            class="p-fieldset p-component mt-2"
+            legend="Heritage Function"
         >
-            <div class="p-inputtext-fluid">
-                <ConceptSelect
-                    id="heritageTheme"
-                    ref="heritageThemeField"
-                    v-model="currentHeritageTheme.heritageTheme"
-                    graph-slug="heritage_site"
-                    node-alias="heritage_theme"
-                    @value-updated="updateSelectValue"
-                />
-            </div>
-            <Button
-                id="addHeritageTheme"
-                label="Add"
-                class="inline-block"
-                :disabled="addOtherHeritageSiteDisabled"
-                :aria_disabled="addOtherHeritageSiteDisabled"
-                @click="saveHeritageTheme"
-            ></Button>
-        </LabelledInput>
-        <MultiValuePlaceholder
-            v-slot="slotProps"
-            :showDeleteButton="true"
-            :displayValues="heritageThemes"
-            label="Theme(s)"
-            :deleteCallback="deleteHeritageThemeCallback"
+            <LabelledInput
+                label="Function Category"
+                input-name="heritageTheme"
+                :error-message="errors.functionCategories?.join(',')"
+                :required="true"
+            >
+                <div class="p-inputtext-fluid flex flex-row">
+                    <FormField
+                        :resolver="resolver"
+                        name="functionCategory"
+                    >
+                        <ConceptSelect
+                            id="functionCategory"
+                            ref="functionCategoryField"
+                            v-model="currentHeritageFunction.functionCategory"
+                            graph-slug="heritage_site"
+                            node-alias="function_category"
+                        />
+                    </FormField>
+                    <div class="inline-block">
+                        <FormField
+                            :resolver="resolver"
+                            name="functionCategoryType"
+                        >
+                            <ConceptRadioButtons
+                                id="functionCategoryType"
+                                ref="functionCategoryTypeRef"
+                                v-model="
+                                    currentHeritageFunction.functionCategoryType
+                                "
+                                graph-slug="heritage_site"
+                                node-alias="functional_category"
+                                group-direction="column"
+                            />
+                        </FormField>
+                    </div>
+                </div>
+                <Button
+                    id="saveFunctionCategory"
+                    label="Add"
+                    class="inline-block"
+                    :disabled="addOtherFunctionCategoryDisabled"
+                    :aria-disabled="addOtherFunctionCategoryDisabled"
+                    @click="saveFunctionCategory"
+                ></Button>
+            </LabelledInput>
+            <MultiValuePlaceholder
+                v-slot="slotProps"
+                :showDeleteButton="true"
+                :displayValues="heritageFunctions"
+                label="Category/Categories"
+                :deleteCallback="deleteFunctionCategoryCallback"
+            >
+                <div
+                    v-for="slot in slotProps"
+                    :key="slot"
+                    class="parent value"
+                >
+                    {{ slot.functionCategory }}
+                    {{ slot.functionCategoryType }}
+                </div>
+            </MultiValuePlaceholder>
+        </Fieldset>
+        <Fieldset
+            id="heritageThemeFieldset"
+            class="p-fieldset p-component mt-2"
+            legend="Heritage Theme"
         >
-            <div class="parent value">{{ slotProps.value }}</div>
-        </MultiValuePlaceholder>
-    </Fieldset>
+            <LabelledInput
+                label="Heritage Theme"
+                input-name="heritageTheme"
+                :error-message="errors.heritageThemes?.join(',')"
+                :required="true"
+            >
+                <div class="p-inputtext-fluid">
+                    <FormField
+                        :resolver="resolver"
+                        name="heritageTheme"
+                    >
+                        <ConceptSelect
+                            id="heritageTheme"
+                            ref="heritageThemeField"
+                            v-model="currentHeritageTheme.heritageTheme"
+                            graph-slug="heritage_site"
+                            node-alias="heritage_theme"
+                        />
+                    </FormField>
+                </div>
+                <Button
+                    id="addHeritageTheme"
+                    label="Add"
+                    class="inline-block"
+                    :disabled="addOtherHeritageSiteDisabled"
+                    :aria_disabled="addOtherHeritageSiteDisabled"
+                    @click="saveHeritageTheme"
+                ></Button>
+            </LabelledInput>
+            <MultiValuePlaceholder
+                v-slot="slotProps"
+                :showDeleteButton="true"
+                :displayValues="heritageThemes"
+                label="Theme(s)"
+                :deleteCallback="deleteHeritageThemeCallback"
+            >
+                <div class="parent value">{{ slotProps.value }}</div>
+            </MultiValuePlaceholder>
+        </Fieldset>
+    </Form>
 </template>
 
 <style>

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -1,16 +1,15 @@
 <script setup lang="ts">
-import { inject, ref, onMounted } from 'vue';
+import { useTemplateRef, inject, ref, onMounted } from 'vue';
 import type { Ref } from 'vue';
 
 import FieldSet from 'primevue/fieldset';
 import InputText from 'primevue/inputtext';
 import Button from 'primevue/button';
-import RadioButton from 'primevue/radiobutton';
-import Select from 'primevue/select';
 import DatePicker from 'primevue/datepicker';
+import { Form, FormField } from '@primevue/forms';
+import type { FormFieldResolverOptions } from '@primevue/forms';
 import ConceptSelect from '@/bcgov_arches_common/components/ConceptSelect/ConceptSelect.vue';
 import ConceptRadioButtons from '@/bcgov_arches_common/components/ConceptSelect/ConceptRadioButtons.vue';
-
 import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePlaceholder/MultiValuePlaceholder.vue';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import type { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
@@ -39,13 +38,13 @@ const currentChronology = ref(getChronologySchema());
 const currentArchitectOrBuilder = ref(getArchitectOrBuilderSchema());
 const currentURL = ref(getRequiredURLsSchema());
 
-const updateSelectValue = function (
-    newValue: string,
-    selectField: typeof RadioButton | typeof ConceptSelect,
-) {
-    console.log(`New value ${newValue}`);
-    // validateField(selectField);
-};
+// const updateSelectValue = function (
+//     newValue: string,
+//     selectField: typeof RadioButton | typeof ConceptSelect,
+// ) {
+//     console.log(`New value ${newValue}`);
+//     // validateField(selectField);
+// };
 
 const architectsOrBuilders = ref([] as Array<string>);
 const urls = ref([] as Array<string>);
@@ -54,33 +53,56 @@ const addURLDisabled = ref(false);
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
 
-const valueChanged = function (event: Event) {
-    console.log(event);
-    validateField(event.target);
+const fields = {
+    eventTypeField: useTemplateRef('eventTypeField'),
+    startYearField: useTemplateRef('startYearField'),
+    endYearField: useTemplateRef('endYearField'),
+    chronologyNotesField: useTemplateRef('chronologyNotesField'),
+    architectOrBuilderNameField: useTemplateRef('architectOrBuilderNameField'),
+    architectOrBuilderTypeField: useTemplateRef('architectOrBuilderTypeField'),
+    architectOrBuilderNotesField: useTemplateRef(
+        'architectOrBuilderNotesField',
+    ),
+    urlTypeField: useTemplateRef('urlTypeField'),
+    linkTextField: useTemplateRef('linkTextField'),
+    urlField: useTemplateRef('urlField'),
+};
+const isValid = () => {
+    // We don't want to validate fields the first time we show the step
+    if (!validateFields) {
+        validateFields = true;
+        return true;
+    }
+    let valid = true;
+
+    for (const field of Object.values(fields) as Array<Ref>) {
+        valid = resolver(field?.value.$el as FormFieldResolverOptions) && valid;
+    }
+    return valid;
 };
 
-const validateField = function (
-    inputField: typeof Select | typeof RadioButton,
-) {
-    if (Object.hasOwn(currentChronology, inputField?.inputId)) {
-        validateChronologyField(inputField as HTMLInputElement);
-    } else if (Object.hasOwn(currentArchitectOrBuilder, inputField?.inputId)) {
-        validateArchitectOrBuilderField(inputField as HTMLInputElement);
-    } else if (Object.hasOwn(currentURL, inputField?.inputId)) {
-        validateURLField(inputField as HTMLInputElement);
+const resolver = function (e: FormFieldResolverOptions): Record<string, any> {
+    if (Object.hasOwn(currentChronology.value, e.name ?? '')) {
+        return validateChronologyField(e as FormFieldResolverOptions);
+    } else if (Object.hasOwn(currentArchitectOrBuilder.value, e.name ?? '')) {
+        return validateArchitectOrBuilderField(e as FormFieldResolverOptions);
+    } else if (Object.hasOwn(currentURL.value, e.name ?? '')) {
+        return validateURLField(e as FormFieldResolverOptions);
     }
+
+    return {};
 };
-const validateSiteDetailsFields = function (field: HTMLInputElement) {
-    console.log(`ID: ${field.id}`);
-    const key: keyof typeof SiteDetails = field.id as keyof typeof SiteDetails;
+const validateSiteDetailsFields = function (
+    event: FormFieldResolverOptions,
+): Record<string, any> {
+    const key: keyof typeof SiteDetails =
+        event.name as keyof typeof SiteDetails;
     const fieldValidation = requiredSiteDetailsSchema.shape[key].safeParse(
         heritageSiteRef.value[key],
     );
     if (fieldValidation.success) {
-        field.classList.remove('p-invalid');
         errors.value[key] = [];
     } else {
-        field.classList.add('p-invalid');
         errors.value[key] = (
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
@@ -88,17 +110,16 @@ const validateSiteDetailsFields = function (field: HTMLInputElement) {
     return fieldValidation.success;
 };
 
-const validateChronologyField = function (field: HTMLInputElement) {
-    console.log(`ID: ${field.id}`);
-    const key: keyof typeof Chronology = field.id as keyof typeof Chronology;
+const validateChronologyField = function (
+    event: FormFieldResolverOptions,
+): Record<string, any> {
+    const key: keyof typeof Chronology = event.name as keyof typeof Chronology;
     const fieldValidation = requiredChronologySchema.shape[key].safeParse(
-        currentChronology[field.id],
+        currentChronology.value[key],
     );
     if (fieldValidation.success) {
-        field.classList.remove('p-invalid');
         errors.value[key] = [];
     } else {
-        field.classList.add('p-invalid');
         errors.value[key] = (
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
@@ -106,18 +127,17 @@ const validateChronologyField = function (field: HTMLInputElement) {
     return fieldValidation.success;
 };
 
-const validateArchitectOrBuilderField = function (field: HTMLInputElement) {
-    console.log(`ID: ${field.id}`);
+const validateArchitectOrBuilderField = function (
+    event: FormFieldResolverOptions,
+): Record<string, any> {
     const key: keyof typeof ArchitectOrBuilder =
-        field.inputId as keyof typeof ArchitectOrBuilder;
+        event.name as keyof typeof ArchitectOrBuilder;
     const fieldValidation = requiredArchitectBuilderSchema.shape[key].safeParse(
-        currentArchitectOrBuilder[field.inputId],
+        currentArchitectOrBuilder.value[key],
     );
     if (fieldValidation.success) {
-        field.classList.remove('p-invalid');
         errors.value[key] = [];
     } else {
-        field.classList.add('p-invalid');
         errors.value[key] = (
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
@@ -125,18 +145,17 @@ const validateArchitectOrBuilderField = function (field: HTMLInputElement) {
     return fieldValidation.success;
 };
 
-const validateURLField = function (field) {
-    console.log(`ID: ${field.inputId}`);
+const validateURLField = function (
+    event: FormFieldResolverOptions,
+): Record<string, any> {
     const key: keyof typeof RequiredURLs =
-        field.inputId as keyof typeof RequiredURLs;
+        event.name as keyof typeof RequiredURLs;
     const fieldValidation = requiredRequiredURLsSchema.shape[key].safeParse(
-        currentURL[field.inputId],
+        currentURL.value[key],
     );
     if (fieldValidation.success) {
-        field.classList.remove('p-invalid');
         errors.value[key] = [];
     } else {
-        field.classList.add('p-invalid');
         errors.value[key] = (
             fieldValidation.error as typeof ZodError
         ).flatten().formErrors;
@@ -216,6 +235,12 @@ const deleteURLCallback = function (index: number) {
     updateAddOtherURL();
 };
 
+let validateFields = false;
+
+// This needs to be removed - added because ESLint was complaining. Need to figure out
+// configuration so API methods are not
+defineExpose({ isValid });
+
 onMounted(() => {
     heritageSiteRef.value.siteDetails.chronologies = chronologies;
     heritageSiteRef.value.siteDetails.architectsOrBuilders =
@@ -228,283 +253,339 @@ onMounted(() => {
 });
 </script>
 <template>
-    <FieldSet
-        id="chronologyFieldset"
-        legend="Chronology"
+    <Form
+        ref="siteDetailsRef"
+        name="siteDetailsRef"
     >
-        <div class="flex flex-row flex-wrap gap-4">
-            <div class="inline-block">
-                <div class="flex flex-col">
-                    <ConceptRadioButtons
-                        id="eventType"
-                        ref="eventTypeField"
-                        v-model="currentChronology.eventType"
-                        graph-slug="heritage_site"
-                        node-alias="chronology"
-                        group-direction="column"
-                        @value-updated="updateSelectValue"
-                    />
-                </div>
-            </div>
-            <label for="startYear">Start Year</label>
-            <DatePicker
-                id="startYear"
-                ref="startYearField"
-                v-model="currentChronology.startYear"
-                class="flex-shrink"
-                dateFormat="yy"
-                view="year"
-                show-icon
-                aria-describedby="start-year-help"
-                aria-required="true"
-                @input="valueChanged"
-            />
-            <label for="endYear">End Year</label>
-            <DatePicker
-                id="endYear"
-                ref="endYearField"
-                v-model="currentChronology.endYear"
-                dateFormat="yy"
-                view="year"
-                show-icon
-                aria-describedby="end-year-help"
-                aria-required="true"
-                @input="valueChanged"
-            />
-            <div class="inline-block">
-                <Checkbox
-                    v-model="currentChronology.circa"
-                    inputId="circa"
-                    value="Circa"
-                    @change="valueChanged"
-                />
-                <label for="circa"> Circa </label>
-            </div>
-        </div>
-        <div class="p-inputtext-fluid">
-            <LabelledInput
-                label="Chronology Notes (Optional)"
-                hint="Enter details about the significant event"
-                input-name="chronologyNotes"
-                :error-message="errors.chronologyNotes?.join(',')"
-            >
-                <div class="">
-                    <InputText
-                        id="chronologyNotes"
-                        ref="chronologyNotesField"
-                        v-model="currentChronology.chronologyNotes"
-                        theme="snow"
-                        aria-describedby="chronology-help"
-                        fluid
-                        class="inline-block"
-                        @editorChange="valueChanged"
-                        @change="valueChanged"
-                    />
-                    <Button
-                        id="saveChronology"
-                        label="Add"
-                        class="inline-block"
-                        @click="saveChronology"
-                    ></Button>
-                </div>
-            </LabelledInput>
-        </div>
-        <MultiValuePlaceholder
-            v-slot="slotProps"
-            label="Chronologies"
-            :showDeleteButton="true"
-            :displayValues="chronologies"
-            :deleteCallback="deleteChronologyCallback"
+        <FieldSet
+            id="chronologyFieldset"
+            legend="Chronology"
         >
-            <div
-                v-for="slot in slotProps"
-                :key="slot"
-                class="parent value"
-            >
-                {{ slot.eventType }} {{ slot.circa }} {{ slot.startYear }}
-                {{ slot.endYear }} {{ slot.chronologyNotes }}
+            <div class="flex flex-row flex-wrap gap-4">
+                <div class="inline-block">
+                    <div class="flex flex-col">
+                        <FormField
+                            :resolver="resolver"
+                            name="eventType"
+                        >
+                            <ConceptRadioButtons
+                                id="eventType"
+                                ref="eventTypeField"
+                                v-model="currentChronology.eventType"
+                                graph-slug="heritage_site"
+                                node-alias="chronology"
+                                group-direction="column"
+                            />
+                        </FormField>
+                    </div>
+                </div>
+                <label for="startYear">Start Year</label>
+                <FormField
+                    :resolver="resolver"
+                    name="startYear"
+                >
+                    <DatePicker
+                        id="startYear"
+                        ref="startYearField"
+                        v-model="currentChronology.startYear"
+                        class="flex-shrink"
+                        dateFormat="yy"
+                        view="year"
+                        show-icon
+                        aria-describedby="start-year-help"
+                        aria-required="true"
+                    />
+                </FormField>
+                <label for="endYear">End Year</label>
+                <FormField
+                    :resolver="resolver"
+                    name="endYear"
+                >
+                    <DatePicker
+                        id="endYear"
+                        ref="endYearField"
+                        v-model="currentChronology.endYear"
+                        dateFormat="yy"
+                        view="year"
+                        show-icon
+                        aria-describedby="end-year-help"
+                        aria-required="true"
+                    />
+                </FormField>
+                <div class="inline-block">
+                    <FormField
+                        :resolver="resolver"
+                        name="circa"
+                    >
+                        <Checkbox
+                            v-model="currentChronology.circa"
+                            inputId="circa"
+                            value="Circa"
+                        />
+                    </FormField>
+                    <label for="circa"> Circa </label>
+                </div>
             </div>
-        </MultiValuePlaceholder>
-    </FieldSet>
-    <Fieldset
-        id="architectsBuildersFieldset"
-        class="p-fieldset p-component mt-2"
-        legend="Architects / Builders"
-    >
-        <div class="p-inputtext-fluid flex">
-            <LabelledInput
-                label="Architect / Builder Name"
-                hint="Enter the company or individual's name"
-                input-name="architectOrBuilderName"
-                class="inline-block"
-                :error-message="errors.architectOrBuilderName?.join(',')"
-                :required="true"
-            >
-                <div class="p-inputtext-fluid">
-                    <InputText
-                        id="architectOrBuilderName"
-                        ref="architectOrBuilderNameField"
-                        v-model="
-                            currentArchitectOrBuilder.architectOrBuilderName
-                        "
-                        aria-describedby="architect-or-builder-help"
-                        aria-required="true"
-                        fluid
-                        @change="valueChanged"
-                    />
-                </div>
-            </LabelledInput>
-            <LabelledInput
-                label="Type"
-                input-name="architectOrBuilderType"
-                :error-message="errors.architectOrBuilderType?.join(',')"
-                :required="true"
-            >
-                <ConceptSelect
-                    id="architectOrBuilderType"
-                    ref="architectOrBuilderTypeField"
-                    v-model="currentArchitectOrBuilder.architectOrBuilderType"
-                    graph-slug="heritage_site"
-                    node-alias="construction_actor_type"
-                    @value-updated="updateSelectValue"
-                />
-            </LabelledInput>
-        </div>
-        <div class="p-inputtext-fluid">
-            <LabelledInput
-                label="Architect / Builder Name Notes (Optional)"
-                hint="Provide any additional comments about the architect/builder"
-                input-name="architectOrBuilderNotes"
-                :error-message="errors.architectOrBuilderNotes?.join(',')"
-                :required="false"
-            >
-                <div class="">
-                    <InputText
-                        id="architectOrBuilderNotes"
-                        ref="architectOrBuilderNotesField"
-                        v-model="
-                            currentArchitectOrBuilder.architectOrBuilderNotes
-                        "
-                        aria-describedby="architect-or-builder-notes-help"
-                        aria-required="true"
-                        fluid
-                        class="inline-block"
-                        @change="valueChanged"
-                    />
-                    <Button
-                        id="addOtherName"
-                        label="Add"
-                        class="inline-block"
-                        @click="saveArchitectOrBuilder"
-                    ></Button>
-                </div>
-            </LabelledInput>
-        </div>
-        <MultiValuePlaceholder
-            v-slot="slotProps"
-            label="Architect(s) / Builder(s)"
-            :showDeleteButton="true"
-            :displayValues="architectsOrBuilders"
-            :deleteCallback="deleteArchitectBuilderCallback"
-        >
-            <div
-                v-for="slot in slotProps"
-                :key="slot"
-                class="parent value"
-            >
-                {{ slot.architectOrBuilderType }}
-                {{ slot.architectOrBuilderName }}
-                {{ slot.architectOrBuilderNotes }}
+            <div class="p-inputtext-fluid">
+                <FormField
+                    :resolver="resolver"
+                    name="chronologyNotes"
+                >
+                    <LabelledInput
+                        label="Chronology Notes (Optional)"
+                        hint="Enter details about the significant event"
+                        input-name="chronologyNotes"
+                        :error-message="errors.chronologyNotes?.join(',')"
+                    >
+                        <div class="">
+                            <InputText
+                                id="chronologyNotes"
+                                ref="chronologyNotesField"
+                                v-model="currentChronology.chronologyNotes"
+                                theme="snow"
+                                aria-describedby="chronology-help"
+                                fluid
+                                class="inline-block"
+                            />
+                            <Button
+                                id="saveChronology"
+                                label="Add"
+                                class="inline-block"
+                                @click="saveChronology"
+                            ></Button>
+                        </div>
+                    </LabelledInput>
+                </FormField>
             </div>
-        </MultiValuePlaceholder>
-    </Fieldset>
-    <Fieldset
-        id="relatedURLsFieldset"
-        class="p-fieldset p-component mt-2"
-        legend="Related URLs"
-    >
-        <div class="flex flex-row">
-            <LabelledInput
-                label="URL Type"
-                hint="Acceptable URL Types"
-                input-name="urlType"
-                :error-message="errors.urlType?.join(',')"
-                :required="true"
-            >
-                <ConceptSelect
-                    id="urlType"
-                    ref="urlTypeField"
-                    v-model="currentURL.urlType"
-                    graph-slug="heritage_site"
-                    node-alias="external_url_type"
-                    placeholder="Select URL Type"
-                    @value-updated="updateSelectValue"
-                />
-            </LabelledInput>
-            <LabelledInput
-                label="Link Text"
-                hint="Enter text that describes the link"
-                input-name="linkText"
-                :error-message="errors.linkText?.join(',')"
-                :required="true"
-            >
-                <div class="p-inputtext-fluid">
-                    <InputText
-                        id="linkText"
-                        ref="linkTextField"
-                        v-model="currentURL.linkText"
-                        aria-describedby="link-text-help"
-                        aria-required="true"
-                        fluid
-                        @change="valueChanged"
-                    />
-                </div>
-            </LabelledInput>
-        </div>
-        <div class="p-inputtext-fluid">
-            <LabelledInput
-                label="URL"
-                hint="URL must be stable and publicly accessible"
-                input-name="url"
-                :error-message="errors.urls?.join(',')"
-                :required="true"
-            >
-                <div class="flex flex-row full-width">
-                    <InputText
-                        id="url"
-                        ref="urlField"
-                        v-model="currentURL.url"
-                        aria-describedby="url-help"
-                        aria-required="true"
-                        fluid
-                        class="inline-block"
-                        @change="valueChanged"
-                    />
-                    <Button
-                        id="saveURL"
-                        label="Add"
-                        class="inline-block"
-                        @click="saveURL"
-                    ></Button>
-                </div>
-            </LabelledInput>
             <MultiValuePlaceholder
                 v-slot="slotProps"
-                label="URL(s)"
+                label="Chronologies"
                 :showDeleteButton="true"
-                :displayValues="urls"
-                :deleteCallback="deleteURLCallback"
+                :displayValues="chronologies"
+                :deleteCallback="deleteChronologyCallback"
             >
                 <div
                     v-for="slot in slotProps"
                     :key="slot"
                     class="parent value"
                 >
-                    {{ slot.urlType }} {{ slot.url }} {{ slot.linkText }}
+                    {{ slot.eventType }} {{ slot.circa }} {{ slot.startYear }}
+                    {{ slot.endYear }} {{ slot.chronologyNotes }}
                 </div>
             </MultiValuePlaceholder>
-        </div>
-    </Fieldset>
+        </FieldSet>
+        <Fieldset
+            id="architectsBuildersFieldset"
+            class="p-fieldset p-component mt-2"
+            legend="Architects / Builders"
+        >
+            <div class="p-inputtext-fluid flex">
+                <FormField
+                    :resolver="resolver"
+                    name="architectOrBuilderName"
+                >
+                    <LabelledInput
+                        label="Architect / Builder Name"
+                        hint="Enter the company or individual's name"
+                        input-name="architectOrBuilderName"
+                        class="inline-block"
+                        :error-message="
+                            errors.architectOrBuilderName?.join(',')
+                        "
+                        :required="true"
+                    >
+                        <div class="p-inputtext-fluid">
+                            <InputText
+                                id="architectOrBuilderName"
+                                ref="architectOrBuilderNameField"
+                                v-model="
+                                    currentArchitectOrBuilder.architectOrBuilderName
+                                "
+                                aria-describedby="architect-or-builder-help"
+                                aria-required="true"
+                                fluid
+                            />
+                        </div>
+                    </LabelledInput>
+                </FormField>
+                <FormField
+                    :resolver="resolver"
+                    name="architectOrBuilderType"
+                >
+                    <LabelledInput
+                        label="Type"
+                        input-name="architectOrBuilderType"
+                        :error-message="
+                            errors.architectOrBuilderType?.join(',')
+                        "
+                        :required="true"
+                    >
+                        <ConceptSelect
+                            id="architectOrBuilderType"
+                            ref="architectOrBuilderTypeField"
+                            v-model="
+                                currentArchitectOrBuilder.architectOrBuilderType
+                            "
+                            graph-slug="heritage_site"
+                            node-alias="construction_actor_type"
+                        />
+                    </LabelledInput>
+                </FormField>
+            </div>
+            <div class="p-inputtext-fluid">
+                <FormField
+                    :resolver="resolver"
+                    name="architectOrBuilderNotes"
+                >
+                    <LabelledInput
+                        label="Architect / Builder Name Notes (Optional)"
+                        hint="Provide any additional comments about the architect/builder"
+                        input-name="architectOrBuilderNotes"
+                        :error-message="
+                            errors.architectOrBuilderNotes?.join(',')
+                        "
+                        :required="false"
+                    >
+                        <div class="">
+                            <InputText
+                                id="architectOrBuilderNotes"
+                                ref="architectOrBuilderNotesField"
+                                v-model="
+                                    currentArchitectOrBuilder.architectOrBuilderNotes
+                                "
+                                aria-describedby="architect-or-builder-notes-help"
+                                aria-required="true"
+                                fluid
+                                class="inline-block"
+                            />
+                            <Button
+                                id="addOtherName"
+                                label="Add"
+                                class="inline-block"
+                                @click="saveArchitectOrBuilder"
+                            ></Button>
+                        </div>
+                    </LabelledInput>
+                </FormField>
+            </div>
+            <MultiValuePlaceholder
+                v-slot="slotProps"
+                label="Architect(s) / Builder(s)"
+                :showDeleteButton="true"
+                :displayValues="architectsOrBuilders"
+                :deleteCallback="deleteArchitectBuilderCallback"
+            >
+                <div
+                    v-for="slot in slotProps"
+                    :key="slot"
+                    class="parent value"
+                >
+                    {{ slot.architectOrBuilderType }}
+                    {{ slot.architectOrBuilderName }}
+                    {{ slot.architectOrBuilderNotes }}
+                </div>
+            </MultiValuePlaceholder>
+        </Fieldset>
+        <Fieldset
+            id="relatedURLsFieldset"
+            class="p-fieldset p-component mt-2"
+            legend="Related URLs"
+        >
+            <div class="flex flex-row">
+                <FormField
+                    :resolver="resolver"
+                    name="urlType"
+                >
+                    <LabelledInput
+                        label="URL Type"
+                        hint="Acceptable URL Types"
+                        input-name="urlType"
+                        :error-message="errors.urlType?.join(',')"
+                        :required="true"
+                    >
+                        <ConceptSelect
+                            id="urlType"
+                            ref="urlTypeField"
+                            v-model="currentURL.urlType"
+                            graph-slug="heritage_site"
+                            node-alias="external_url_type"
+                            placeholder="Select URL Type"
+                        />
+                    </LabelledInput>
+                </FormField>
+                <FormField
+                    :resolver="resolver"
+                    name="linkText"
+                >
+                    <LabelledInput
+                        label="Link Text"
+                        hint="Enter text that describes the link"
+                        input-name="linkText"
+                        :error-message="errors.linkText?.join(',')"
+                        :required="true"
+                    >
+                        <div class="p-inputtext-fluid">
+                            <InputText
+                                id="linkText"
+                                ref="linkTextField"
+                                v-model="currentURL.linkText"
+                                aria-describedby="link-text-help"
+                                aria-required="true"
+                                fluid
+                            />
+                        </div>
+                    </LabelledInput>
+                </FormField>
+            </div>
+            <div class="p-inputtext-fluid">
+                <FormField
+                    :resolver="resolver"
+                    name="url"
+                >
+                    <LabelledInput
+                        label="URL"
+                        hint="URL must be stable and publicly accessible"
+                        input-name="url"
+                        :error-message="errors.url?.join(',')"
+                        :required="true"
+                    >
+                        <div class="flex flex-row full-width">
+                            <InputText
+                                id="url"
+                                ref="urlField"
+                                v-model="currentURL.url"
+                                aria-describedby="url-help"
+                                aria-required="true"
+                                fluid
+                                class="inline-block"
+                            />
+                            <Button
+                                id="saveURL"
+                                label="Add"
+                                class="inline-block"
+                                @click="saveURL"
+                            ></Button>
+                        </div>
+                    </LabelledInput>
+                </FormField>
+                <MultiValuePlaceholder
+                    v-slot="slotProps"
+                    label="URL(s)"
+                    :showDeleteButton="true"
+                    :displayValues="urls"
+                    :deleteCallback="deleteURLCallback"
+                >
+                    <div
+                        v-for="slot in slotProps"
+                        :key="slot"
+                        class="parent value"
+                    >
+                        {{ slot.urlType }} {{ slot.url }} {{ slot.linkText }}
+                    </div>
+                </MultiValuePlaceholder>
+            </div>
+        </Fieldset>
+    </Form>
 </template>
 
 <style>

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -76,7 +76,10 @@ const isValid = () => {
     let valid = true;
 
     for (const field of Object.values(fields) as Array<Ref>) {
-        valid = resolver(field?.value.$el as FormFieldResolverOptions) && valid;
+        valid =
+            resolver({
+                name: field?.value.$el.id,
+            } as FormFieldResolverOptions) && valid;
     }
     return valid;
 };

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -186,7 +186,7 @@ const saveChronology = function () {
         eventType: currentChronology.value.eventType,
         startYear: currentChronology.value.startYear,
         endYear: currentChronology.value.endYear,
-        circa: currentChronology.value.circa,
+        circa: currentChronology.value.circa?.toString(),
         chronologyNotes: currentChronology.value.chronologyNotes,
     });
 

--- a/bcrhp/src/bcrhp/schema/SiteClassificationSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteClassificationSchema.ts
@@ -7,7 +7,7 @@ const SiteClassificationSchema = z.object({
 });
 const HeritageClassSchema = z.object({
     contributingResources: z
-        .string()
+        .number()
         .min(1, { message: 'Number of Contributing Resources is required.' })
         .max(250),
     heritageCategory: z
@@ -75,11 +75,11 @@ class SiteClassification implements SiteClassificationType {
 
 class HeritageClass implements HeritageClassType {
     constructor() {
-        this.contributingResources = '';
+        this.contributingResources = 0;
         this.heritageCategory = '';
         this.ownership = '';
     }
-    contributingResources: string;
+    contributingResources: number;
     heritageCategory: string;
     ownership: string;
 }

--- a/bcrhp/src/bcrhp/schema/SiteClassificationSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteClassificationSchema.ts
@@ -7,7 +7,7 @@ const SiteClassificationSchema = z.object({
 });
 const HeritageClassSchema = z.object({
     contributingResources: z
-        .number()
+        .string()
         .min(1, { message: 'Number of Contributing Resources is required.' })
         .max(250),
     heritageCategory: z
@@ -75,11 +75,11 @@ class SiteClassification implements SiteClassificationType {
 
 class HeritageClass implements HeritageClassType {
     constructor() {
-        this.contributingResources = 0;
+        this.contributingResources = '';
         this.heritageCategory = '';
         this.ownership = '';
     }
-    contributingResources: number;
+    contributingResources: string;
     heritageCategory: string;
     ownership: string;
 }

--- a/bcrhp/src/bcrhp/schema/SiteDetailsSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteDetailsSchema.ts
@@ -26,9 +26,8 @@ const ArchitectBuilderSchema = z.object({
 });
 
 const RequiredURLsSchema = z.object({
-    urlType: z.array(z.string()).max(250),
-    urlText: z.string().min(1, { message: 'URL Type is required.' }).max(250),
-    linkText: z.string().min(1, { message: 'URL Text is required.' }).max(250),
+    urlType: z.string().min(1, { message: 'URL Type is required.' }).max(250),
+    linkText: z.string().min(1, { message: 'Link Text is required.' }).max(250),
     url: z.string().min(1, { message: 'URL is required.' }).max(250),
 });
 

--- a/bcrhp/src/bcrhp/schema/SiteImagesSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteImagesSchema.ts
@@ -10,10 +10,7 @@ const SiteImagesSchema = z.object({
         .min(1, { message: 'Image View is required.' })
         .max(250),
     imageFeatures: z.string().max(250),
-    imageDate: z
-        .string()
-        .min(1, { message: 'Image Date is required.' })
-        .max(250),
+    imageDate: z.date(),
     imageDescription: z
         .string()
         .min(1, { message: 'Image Description is required.' })
@@ -37,7 +34,7 @@ class SiteImages implements SiteImagesType {
         this.imageType = '';
         this.imageView = '';
         this.imageFeatures = '';
-        this.imageDate = '';
+        this.imageDate = null;
         this.imageDescription = '';
         this.photographer = '';
         this.copyright = '';
@@ -46,7 +43,7 @@ class SiteImages implements SiteImagesType {
     imageType: string;
     imageView: string;
     imageFeatures: string;
-    imageDate: string;
+    imageDate: Date | null;
     imageDescription: string;
     photographer: string;
     copyright: string;


### PR DESCRIPTION
his PR implements the Vue Form Library on Step6_SOS, Step7_SiteImages, Step8_SiteClassification, Step9_SiteDetails and Step10_SupportingDocuments, and ensures that the existing Zod validation works with it.

It also resolves merge conflicts between `origin/yg/feat/1276-implement-primevue-form-component-on-step6-step10` and `origin/yg/feat/merge-1276-into-1.4.0_site_submission` which were primarily on Step8_SiteClassification and Step9_SiteDetails.