### PR TITLE
Yg/bug/merge 1271 into 1.4.0 site submission

### DIFF
--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -101,6 +101,10 @@ const saveRecognitionDetails = function () {
         referenceNumber: currentRecognitionDetails.value.referenceNumber,
     });
 
+    currentRecognitionDetails.value.designationDate = null;
+    currentRecognitionDetails.value.legislativeAct = '';
+    currentRecognitionDetails.value.referenceNumber = '';
+
     updateAddOtherRecognitionDetails();
 };
 

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -165,6 +165,10 @@ const saveHeritageClass = function () {
         ownership: currentHeritageClass.value.ownership,
     });
 
+    currentHeritageClass.value.contributingResources = 0;
+    currentHeritageClass.value.heritageCategory = '';
+    currentHeritageClass.value.ownership = '';
+
     updateAddHeritageClassCategory();
 };
 
@@ -176,6 +180,9 @@ const saveFunctionCategory = function () {
             currentHeritageFunction.value.functionCategoryType,
     });
 
+    currentHeritageFunction.value.functionCategory = '';
+    currentHeritageFunction.value.functionCategoryType = '';
+
     updateAddOtherFunctionCategory();
 };
 
@@ -184,6 +191,8 @@ const saveHeritageTheme = function () {
     heritageSiteRef.value.siteClassification.heritageThemes.push(
         currentHeritageTheme.value.heritageTheme,
     );
+
+    currentHeritageTheme.value.heritageTheme = '';
 
     updateAddOtherHeritageSite();
 };

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -171,6 +171,12 @@ const saveChronology = function () {
         chronologyNotes: currentChronology.value.chronologyNotes,
     });
 
+    currentChronology.value.eventType = '';
+    currentChronology.value.startYear = null;
+    currentChronology.value.endYear = null;
+    currentChronology.value.circa = false;
+    currentChronology.value.chronologyNotes = '';
+
     updateAddChronology();
 };
 
@@ -185,6 +191,10 @@ const saveArchitectOrBuilder = function () {
             currentArchitectOrBuilder.value.architectOrBuilderNotes,
     });
 
+    currentArchitectOrBuilder.value.architectOrBuilderName = '';
+    currentArchitectOrBuilder.value.architectOrBuilderType = '';
+    currentArchitectOrBuilder.value.architectOrBuilderNotes = '';
+
     updateAddOtherArchitectOrBuilder();
 };
 const saveURL = function () {
@@ -194,6 +204,10 @@ const saveURL = function () {
         linkText: currentURL.value.linkText,
         url: currentURL.value.url,
     });
+
+    currentURL.value.urlType = '';
+    currentURL.value.linkText = '';
+    currentURL.value.url = '';
 
     updateAddOtherURL();
 };


### PR DESCRIPTION
This PR fixes a bug where the entered values would not be cleared after being added on Step5_RecognitionDetails, Step8_SiteClassification and Step9_SiteDetails.

It also resolves any merge conflicts between `yg/bug/merge-1271-into-1.4.0_site_submission` and `origin/release/1.4.0_site_submission`.