### PR TITLE
Update all DatePicker widgets to show calendar icon and format date

### DIFF
--- a/bcrhp/src/bcrhp/constants.ts
+++ b/bcrhp/src/bcrhp/constants.ts
@@ -1,1 +1,1 @@
-export const datePickerFormat = 'yy-mm-dd';
+export const DATE_FORMAT = 'yy-MM-dd';

--- a/bcrhp/src/bcrhp/constants.ts
+++ b/bcrhp/src/bcrhp/constants.ts
@@ -1,0 +1,1 @@
+export const datePickerFormat = 'yy-mm-dd';

--- a/bcrhp/src/bcrhp/pages/steps/Step11_ReviewSubmission.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step11_ReviewSubmission.vue
@@ -90,21 +90,23 @@ const heritageSite: typeof HeritageSite = inject(
         >
             <div display="flex flex-col">
                 <div>Type</div>
-                <div class="justify-self-center">{{ image.imageType }}</div>
+                <div class="justify-self-center">{{ image?.imageType }}</div>
                 <div>View</div>
-                <div class="justify-self-center">{{ image.imageView }}</div>
+                <div class="justify-self-center">{{ image?.imageView }}</div>
                 <div>Features</div>
-                <div class="justify-self-center">{{ image.imageFeatures }}</div>
+                <div class="justify-self-center">
+                    {{ image?.imageFeatures }}
+                </div>
                 <div>Date</div>
-                <div class="justify-self-center">{{ image.imageDate }}</div>
+                <div class="justify-self-center">{{ image?.imageDate }}</div>
                 <div>Description</div>
                 <div class="justify-self-center">
-                    {{ image.imageDescription }}
+                    {{ image?.imageDescription }}
                 </div>
                 <div>Photographer</div>
-                <div class="justify-self-center">{{ image.photographer }}</div>
+                <div class="justify-self-center">{{ image?.photographer }}</div>
                 <div>Copyright</div>
-                <div class="justify-self-center">{{ image.copyright }}</div>
+                <div class="justify-self-center">{{ image?.copyright }}</div>
             </div>
         </div>
         <div>

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useTemplateRef, inject, ref, onMounted, watch } from 'vue';
+import { useTemplateRef, inject, ref, onMounted, watch, provide } from 'vue';
 import type { Ref } from 'vue';
 
 import FieldSet from 'primevue/fieldset';
@@ -19,8 +19,11 @@ import {
     requiredRecognitionDetailsSchema,
     getRecognitionDetails,
 } from '@/bcrhp/schema/RecognitionDetailsSchema.ts';
+import { datePickerFormat } from '@/bcrhp/constants.ts';
 
 import type { ZodError } from 'zod';
+
+provide('datePickerFormat', datePickerFormat);
 
 const heritageSite: typeof HeritageSite = inject(
     'heritageSite',
@@ -105,7 +108,10 @@ const validateField = function (
 const saveRecognitionDetails = function () {
     console.log('saveRecognitionDetails');
     heritageSiteRef.value.recognitionDetails.totalRecognitionDetails.push({
-        designationDate: currentRecognitionDetails.value.designationDate,
+        designationDate:
+            currentRecognitionDetails.value.designationDate.toLocaleDateString(
+                'en-CA',
+            ),
         legislativeAct: currentRecognitionDetails.value.legislativeAct,
         referenceNumber: currentRecognitionDetails.value.referenceNumber,
     });
@@ -161,7 +167,8 @@ onMounted(() => {
                             ref="designationDateField"
                             v-model="currentRecognitionDetails.designationDate"
                             name="designationDate"
-                            dateFormat="mm/dd/yy"
+                            :dateFormat="datePickerFormat"
+                            showIcon
                             aria-describedby="designation-date-help"
                             aria-required="true"
                         />

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useTemplateRef, inject, ref, onMounted, watch, provide } from 'vue';
+import { useTemplateRef, inject, ref, onMounted, watch } from 'vue';
 import type { Ref } from 'vue';
 
 import FieldSet from 'primevue/fieldset';
@@ -19,11 +19,9 @@ import {
     requiredRecognitionDetailsSchema,
     getRecognitionDetails,
 } from '@/bcrhp/schema/RecognitionDetailsSchema.ts';
-import { datePickerFormat } from '@/bcrhp/constants.ts';
+import { DATE_FORMAT } from '@/bcrhp/constants.ts';
 
 import type { ZodError } from 'zod';
-
-provide('datePickerFormat', datePickerFormat);
 
 const heritageSite: typeof HeritageSite = inject(
     'heritageSite',
@@ -111,6 +109,11 @@ const saveRecognitionDetails = function () {
         designationDate:
             currentRecognitionDetails.value.designationDate.toLocaleDateString(
                 'en-CA',
+                {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                },
             ),
         legislativeAct: currentRecognitionDetails.value.legislativeAct,
         referenceNumber: currentRecognitionDetails.value.referenceNumber,
@@ -167,7 +170,7 @@ onMounted(() => {
                             ref="designationDateField"
                             v-model="currentRecognitionDetails.designationDate"
                             name="designationDate"
-                            :dateFormat="datePickerFormat"
+                            :dateFormat="DATE_FORMAT"
                             showIcon
                             aria-describedby="designation-date-help"
                             aria-required="true"

--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useTemplateRef, inject, ref, provide } from 'vue';
+import { useTemplateRef, inject, ref } from 'vue';
 import type { Ref } from 'vue';
 
 import InputText from 'primevue/inputtext';
@@ -15,7 +15,7 @@ import {
     requiredSiteImagesSchema,
     getSiteImages,
 } from '@/bcrhp/schema/SiteImagesSchema.ts';
-import { datePickerFormat } from '@/bcrhp/constants.ts';
+import { DATE_FORMAT } from '@/bcrhp/constants.ts';
 
 import type { ZodError } from 'zod';
 
@@ -23,8 +23,6 @@ const heritageSite: typeof HeritageSite = inject(
     'heritageSite',
 ) as typeof HeritageSite;
 const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
-
-provide('datePickerFormat', datePickerFormat);
 
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
@@ -81,7 +79,11 @@ const validateField = function (
     );
     if (imageDate.value instanceof Date) {
         heritageSite.value.siteImages[currentSiteImage.value.id].imageDate =
-            imageDate.value.toLocaleDateString('en-CA');
+            imageDate.value.toLocaleDateString('en-CA', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+            });
     }
 
     if (fieldValidation.success) {
@@ -215,7 +217,7 @@ const updateImageType = function (
                     id="imageDate"
                     ref="imageDateField"
                     v-model="imageDate"
-                    :dateFormat="datePickerFormat"
+                    :dateFormat="DATE_FORMAT"
                     showIcon
                     aria-describedby="image-date-help"
                     aria-required="true"

--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useTemplateRef, inject, ref, onMounted } from 'vue';
+import { useTemplateRef, inject, ref, provide } from 'vue';
 import type { Ref } from 'vue';
 
 import InputText from 'primevue/inputtext';
@@ -15,6 +15,8 @@ import {
     requiredSiteImagesSchema,
     getSiteImages,
 } from '@/bcrhp/schema/SiteImagesSchema.ts';
+import { datePickerFormat } from '@/bcrhp/constants.ts';
+
 import type { ZodError } from 'zod';
 
 const heritageSite: typeof HeritageSite = inject(
@@ -22,10 +24,13 @@ const heritageSite: typeof HeritageSite = inject(
 ) as typeof HeritageSite;
 const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 
+provide('datePickerFormat', datePickerFormat);
+
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
 
 const currentSiteImage = ref(getSiteImages());
+const imageDate = ref();
 currentSiteImage.value.imageTypes = [];
 heritageSite.value.siteImages[currentSiteImage.value.id] = currentSiteImage;
 
@@ -74,6 +79,10 @@ const validateField = function (
     const fieldValidation = requiredSiteImagesSchema.shape[key].safeParse(
         heritageSiteRef.value.siteImages[key],
     );
+    if (imageDate.value instanceof Date) {
+        heritageSite.value.siteImages[currentSiteImage.value.id].imageDate =
+            imageDate.value.toLocaleDateString('en-CA');
+    }
 
     if (fieldValidation.success) {
         errors.value[key] = [];
@@ -101,8 +110,6 @@ const updateImageType = function (
     console.log(`New value ${newValue}`);
     currentSiteImage.value[selectField.id] = newValue;
 };
-
-onMounted(() => {});
 </script>
 <template>
     <Form
@@ -185,7 +192,7 @@ onMounted(() => {});
                     <InputText
                         id="imageFeatures"
                         ref="imageFeaturesField"
-                        v-model="heritageSite.siteImages.imageFeatures"
+                        v-model="currentSiteImage.imageFeatures"
                         aria-describedby="image-features-help"
                         fluid
                         class="inline-block"
@@ -207,8 +214,9 @@ onMounted(() => {});
                 <DatePicker
                     id="imageDate"
                     ref="imageDateField"
-                    v-model="heritageSite.siteImages.imageDate"
-                    show-icon
+                    v-model="imageDate"
+                    :dateFormat="datePickerFormat"
+                    showIcon
                     aria-describedby="image-date-help"
                     aria-required="true"
                 />
@@ -229,7 +237,7 @@ onMounted(() => {});
                     <Editor
                         id="imageDescription"
                         ref="imageDescriptionField"
-                        v-model="heritageSite.siteImages.imageDescription"
+                        v-model="currentSiteImage.imageDescription"
                         theme="snow"
                         aria-describedby="image-description-help"
                         aria-required="true"
@@ -252,7 +260,7 @@ onMounted(() => {});
                     <InputText
                         id="photographer"
                         ref="photographerField"
-                        v-model="heritageSite.siteImages.photographer"
+                        v-model="currentSiteImage.photographer"
                         aria-describedby="image-features-help"
                         aria-required="true"
                         fluid
@@ -275,7 +283,7 @@ onMounted(() => {});
                     <InputText
                         id="copyright"
                         ref="copyrightField"
-                        v-model="heritageSite.siteImages.copyright"
+                        v-model="currentSiteImage.copyright"
                         aria-describedby="copyright-help"
                         aria-required="true"
                         fluid

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -206,8 +206,15 @@ const saveChronology = function () {
     console.log('saveChronology');
     heritageSiteRef.value.siteDetails.chronologies.push({
         eventType: currentChronology.value.eventType,
-        startYear: currentChronology.value.startYear,
-        endYear: currentChronology.value.endYear,
+        startYear: currentChronology.value.startYear.toLocaleDateString(
+            'en-CA',
+            {
+                year: 'numeric',
+            },
+        ),
+        endYear: currentChronology.value.endYear.toLocaleDateString('en-CA', {
+            year: 'numeric',
+        }),
         circa: currentChronology.value.circa?.toString(),
         chronologyNotes: currentChronology.value.chronologyNotes,
     });
@@ -313,7 +320,7 @@ onMounted(() => {
                         class="flex-shrink"
                         dateFormat="yy"
                         view="year"
-                        show-icon
+                        showIcon
                         aria-describedby="start-year-help"
                         aria-required="true"
                     />
@@ -329,7 +336,7 @@ onMounted(() => {
                         v-model="currentChronology.endYear"
                         dateFormat="yy"
                         view="year"
-                        show-icon
+                        showIcon
                         aria-describedby="end-year-help"
                         aria-required="true"
                     />


### PR DESCRIPTION
This PR adds the calendar icon to all the DatePicker widgets on Step5_RecognitionDetails, Step7_SiteImages and Step9_SiteDetails. Additionally, it formats all the selected dates to just display the selected year, as per the Figma design.
Lastly, it fixes a bug on Step7_SiteImages where the  local 'currentImage' was not utilized in the models as well as a bug on Step11_ReviewSubmission, where 'image' could be undefined an an error would be seen in the console.