### PR TITLE
Delegate 'Add' button state to Zod

### DIFF
--- a/bcrhp/src/bcrhp/pages/steps/Step4_SiteNames.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step4_SiteNames.vue
@@ -22,6 +22,7 @@ const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 type FormErrors = Partial<Record<keyof typeof HeritageSite, string[]>>;
 const errors: Ref<FormErrors> = ref<FormErrors>({});
 
+const commonName = ref('');
 const otherName = ref('');
 const otherNames = ref([] as Array<string>);
 
@@ -31,6 +32,9 @@ const fields = {
     otherNameField: useTemplateRef('otherNameField'),
 };
 
+watch(commonName, () => {
+    updateAddOtherState();
+});
 watch(otherName, () => {
     updateAddOtherState();
 });
@@ -53,8 +57,13 @@ const isValid = () => {
 };
 
 const updateAddOtherState = function () {
+    const isValidCommonName = commonName.value
+        ? requiredHeritageSiteSchema.shape['commonName'].safeParse(
+              commonName.value,
+          )
+        : { success: false };
     addOtherNameDisabled.value =
-        otherName.value.length < 1 ||
+        !isValidCommonName.success ||
         heritageSiteRef.value.otherNames.length > 4;
 };
 
@@ -68,9 +77,8 @@ const validateField = function (
     const key: keyof typeof HeritageSite =
         event.name as keyof typeof HeritageSite;
     const fieldValidation = requiredHeritageSiteSchema.shape[key].safeParse(
-        heritageSiteRef.value[key],
+        commonName.value,
     );
-
     if (fieldValidation.success) {
         errors.value[key] = [];
     } else {
@@ -84,8 +92,11 @@ const validateField = function (
 
 const saveOtherName = function () {
     console.log('saveOtherName');
+    heritageSiteRef.value.commonName = commonName.value;
     heritageSiteRef.value.otherNames.push(otherName.value);
+    commonName.value = '';
     otherName.value = '';
+
     updateAddOtherState();
 };
 
@@ -126,7 +137,7 @@ onMounted(() => {
                         <InputText
                             id="commonName"
                             ref="commonNameField"
-                            v-model="heritageSite.commonName"
+                            v-model="commonName"
                             name="commonName"
                             aria-describedby="username-help"
                             aria-required="true"
@@ -136,7 +147,6 @@ onMounted(() => {
                 </LabelledInput>
             </FormField>
             <FormField
-                v-slot="$field"
                 :resolver="resolver"
                 name="otherName"
             >
@@ -144,7 +154,6 @@ onMounted(() => {
                     label="Other Names (Optional)"
                     hint="Click Add to enter one or more additional names as applicable"
                     input-name="otherName"
-                    :error-message="$field.error?.message"
                 >
                     <InputText
                         id="otherName"

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -68,11 +68,29 @@ const isValid = () => {
 };
 
 const updateAddOtherRecognitionDetails = function () {
+    const isValidDesignationDate = currentRecognitionDetails.value
+        .designationDate
+        ? requiredRecognitionDetailsSchema.shape['designationDate'].safeParse(
+              heritageSiteRef.value.recognitionDetails['designationDate'],
+          )
+        : { success: false };
+    const isValidLegislativeAct = currentRecognitionDetails.value.legislativeAct
+        ? requiredRecognitionDetailsSchema.shape['legislativeAct'].safeParse(
+              heritageSiteRef.value.recognitionDetails['legislativeAct'],
+          )
+        : { success: false };
+    const isValidReferenceNumber = currentRecognitionDetails.value
+        .referenceNumber
+        ? requiredRecognitionDetailsSchema.shape['referenceNumber'].safeParse(
+              heritageSiteRef.value.recognitionDetails['referenceNumber'],
+          )
+        : { success: false };
+
     addOtherReferenceNumberDisabled.value =
         !(
-            currentRecognitionDetails.value.designationDate &&
-            currentRecognitionDetails.value.legislativeAct &&
-            currentRecognitionDetails.value.referenceNumber
+            isValidDesignationDate.success &&
+            isValidLegislativeAct.success &&
+            isValidReferenceNumber.success
         ) ||
         heritageSiteRef.value.recognitionDetails.totalRecognitionDetails
             .length > 4;
@@ -90,7 +108,6 @@ const validateField = function (
     const fieldValidation = requiredRecognitionDetailsSchema.shape[
         key
     ].safeParse(heritageSiteRef.value.recognitionDetails[key]);
-
     if (fieldValidation.success) {
         errors.value[key] = [];
     } else {

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -100,25 +100,61 @@ const resolver = function (e: FormFieldResolverOptions): Record<string, any> {
 };
 
 const updateAddOtherHeritageClass = function () {
+    const isValidContributingResources = currentHeritageClass.value
+        .contributingResources
+        ? requiredHeritageClassSchema.shape['contributingResources'].safeParse(
+              parseInt(currentHeritageClass.value.contributingResources),
+          )
+        : { success: false };
+    const isValidHeritageCategory = currentHeritageClass.value.heritageCategory
+        ? requiredHeritageClassSchema.shape['heritageCategory'].safeParse(
+              currentHeritageClass.value.heritageCategory,
+          )
+        : { success: false };
+    const isValidOwnership = currentHeritageClass.value.ownership
+        ? requiredHeritageClassSchema.shape['ownership'].safeParse(
+              currentHeritageClass.value.ownership,
+          )
+        : { success: false };
+
     addOtherHeritageClassDisabled.value =
         !(
-            currentHeritageClass.value.contributingResources &&
-            currentHeritageClass.value.heritageCategory &&
-            currentHeritageClass.value.ownership
+            isValidContributingResources.success &&
+            isValidHeritageCategory.success &&
+            isValidOwnership.success
         ) ||
         heritageSiteRef.value.siteClassification.heritageClasses.length > 4;
 };
 const updateAddOtherHeritageFunction = function () {
+    const isValidFunctionCategory = currentHeritageFunction.value
+        .functionCategory
+        ? requiredHeritageClassSchema.shape['functionCategory'].safeParse(
+              currentHeritageFunction.value.functionCategory,
+          )
+        : { success: false };
+    const isValidFunctionCategoryType = currentHeritageFunction.value
+        .functionCategoryType
+        ? requiredHeritageClassSchema.shape['functionCategoryType'].safeParse(
+              currentHeritageFunction.value.functionCategoryType,
+          )
+        : { success: false };
+
     addOtherHeritageFunctionDisabled.value =
         !(
-            currentHeritageFunction.value.functionCategory &&
-            currentHeritageFunction.value.functionCategoryType
+            isValidFunctionCategory.success &&
+            isValidFunctionCategoryType.success
         ) ||
         heritageSiteRef.value.siteClassification.heritageFunctions.length > 4;
 };
 const updateAddOtherHeritageTheme = function () {
+    const isValidHeritageTheme = currentHeritageTheme.value.heritageTheme
+        ? requiredHeritageClassSchema.shape['heritageTheme'].safeParse(
+              currentHeritageTheme.value.heritageTheme,
+          )
+        : { success: false };
+
     addOtherHeritageThemeDisabled.value =
-        !currentHeritageTheme.value.heritageTheme ||
+        !isValidHeritageTheme.success ||
         heritageSiteRef.value.siteClassification.heritageThemes.length > 4;
 };
 

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -17,14 +17,14 @@ import {
     SiteDetails,
     Chronology,
     ArchitectOrBuilder,
-    RequiredURLs,
+    URLs,
     requiredSiteDetailsSchema,
     requiredChronologySchema,
     requiredArchitectBuilderSchema,
-    requiredRequiredURLsSchema,
+    requiredURLsSchema,
     getArchitectOrBuilderSchema,
     getChronologySchema,
-    getRequiredURLsSchema,
+    getURLsSchema,
 } from '@/bcrhp/schema/SiteDetailsSchema.ts';
 import type { ZodError } from 'zod';
 
@@ -36,7 +36,7 @@ const chronologies = ref([] as Array<string>);
 
 const currentChronology = ref(getChronologySchema());
 const currentArchitectOrBuilder = ref(getArchitectOrBuilderSchema());
-const currentURL = ref(getRequiredURLsSchema());
+const currentURL = ref(getURLsSchema());
 
 // const updateSelectValue = function (
 //     newValue: string,
@@ -163,9 +163,8 @@ const validateArchitectOrBuilderField = function (
 const validateURLField = function (
     event: FormFieldResolverOptions,
 ): Record<string, any> {
-    const key: keyof typeof RequiredURLs =
-        event.name as keyof typeof RequiredURLs;
-    const fieldValidation = requiredRequiredURLsSchema.shape[key].safeParse(
+    const key: keyof typeof URLs = event.name as keyof typeof URLs;
+    const fieldValidation = requiredURLsSchema.shape[key].safeParse(
         currentURL.value[key],
     );
     if (fieldValidation.success) {
@@ -179,26 +178,69 @@ const validateURLField = function (
 };
 
 const updateAddChronology = function () {
+    const isValidEventType = currentChronology.value.eventType
+        ? requiredChronologySchema.shape['eventType'].safeParse(
+              currentChronology.value.eventType,
+          )
+        : { success: false };
+    const isValidStartYear = currentChronology.value.startYear
+        ? requiredChronologySchema.shape['startYear'].safeParse(
+              currentChronology.value.startYear,
+          )
+        : { success: false };
+    const isValidEndYear = currentChronology.value.endYear
+        ? requiredChronologySchema.shape['endYear'].safeParse(
+              currentChronology.value.endYear,
+          )
+        : { success: false };
+
     addChronologyDisabled.value =
         !(
-            currentChronology.value.eventType &&
-            currentChronology.value.startYear &&
-            currentChronology.value.endYear
+            isValidEventType.success &&
+            isValidStartYear.success &&
+            isValidEndYear.success
         ) || heritageSiteRef.value.siteDetails.chronologies.length > 4;
 };
 const updateAddOtherArchitectOrBuilder = function () {
+    const isValidArchitectOrBuilderName = currentArchitectOrBuilder.value
+        .architectOrBuilderName
+        ? requiredArchitectBuilderSchema.shape[
+              'architectOrBuilderName'
+          ].safeParse(currentArchitectOrBuilder.value.architectOrBuilderName)
+        : { success: false };
+    const isValidArchitectOrBuilderType = currentArchitectOrBuilder.value
+        .architectOrBuilderType
+        ? requiredArchitectBuilderSchema.shape[
+              'architectOrBuilderType'
+          ].safeParse(currentArchitectOrBuilder.value.architectOrBuilderType)
+        : { success: false };
+
     addArchitectOrBuilderDisabled.value =
         !(
-            currentArchitectOrBuilder.value.architectOrBuilderName &&
-            currentArchitectOrBuilder.value.architectOrBuilderType
+            isValidArchitectOrBuilderName.success &&
+            isValidArchitectOrBuilderType.success
         ) || heritageSiteRef.value.siteDetails.architectsOrBuilders.length > 4;
 };
 const updateAddOtherURL = function () {
+    const isValidURLType = currentURL.value.urlType
+        ? requiredURLsSchema.shape['urlType'].safeParse(
+              currentURL.value.urlType,
+          )
+        : { success: false };
+    const isValidLinkText = currentURL.value.linkText
+        ? requiredURLsSchema.shape['linkText'].safeParse(
+              currentURL.value.linkText,
+          )
+        : { success: false };
+    const isValidURL = currentURL.value.url
+        ? requiredURLsSchema.shape['url'].safeParse(currentURL.value.url)
+        : { success: false };
+
     addURLDisabled.value =
         !(
-            currentURL.value.urlType &&
-            currentURL.value.linkText &&
-            currentURL.value.url
+            isValidURLType.success &&
+            isValidLinkText.success &&
+            isValidURL.success
         ) || heritageSiteRef.value.siteDetails.urls.length > 4;
 };
 

--- a/bcrhp/src/bcrhp/schema/SiteDetailsSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteDetailsSchema.ts
@@ -25,7 +25,7 @@ const ArchitectBuilderSchema = z.object({
         .max(250),
 });
 
-const RequiredURLsSchema = z.object({
+const URLsSchema = z.object({
     urlType: z.string().min(1, { message: 'URL Type is required.' }).max(250),
     linkText: z.string().min(1, { message: 'Link Text is required.' }).max(250),
     url: z.string().min(1, { message: 'URL is required.' }).max(250),
@@ -34,7 +34,7 @@ const RequiredURLsSchema = z.object({
 const requiredSiteDetailsSchema = SiteDetailsSchema.partial({});
 const requiredChronologySchema = ChronologySchema.partial({});
 const requiredArchitectBuilderSchema = ArchitectBuilderSchema.partial({});
-const requiredRequiredURLsSchema = RequiredURLsSchema.partial({});
+const requiredURLsSchema = URLsSchema.partial({});
 
 // @ts-ignore
 type SiteDetailsType = z.infer<typeof SiteDetailsSchema>;
@@ -43,7 +43,7 @@ type ChronologyType = z.infer<typeof ChronologySchema>;
 // @ts-ignore
 type ArchitectOrBuilderType = z.infer<typeof ArchitectOrBuilderSchema>;
 // @ts-ignore
-type RequiredURLsType = z.infer<typeof RequiredURLsSchema>;
+type URLsType = z.infer<typeof URLsSchema>;
 
 function getSiteDetailsSchema(): SiteDetailsType {
     return new SiteDetails();
@@ -54,8 +54,8 @@ function getChronologySchema(): ChronologyType {
 function getArchitectOrBuilderSchema(): ArchitectOrBuilderType {
     return new ArchitectOrBuilder();
 }
-function getRequiredURLsSchema(): RequiredURLsType {
-    return new RequiredURLs();
+function getURLsSchema(): URLsType {
+    return new URLs();
 }
 
 // @todo - Figure out object state - New/Updated/Deleted
@@ -93,7 +93,7 @@ class ArchitectOrBuilder implements ArchitectOrBuilderType {
     architectOrBuilderNotes: string;
     architectOrBuilderType: string;
 }
-class RequiredURLs implements RequiredURLsType {
+class URLs implements URLsType {
     constructor() {
         this.urlType = '';
         this.linkText = '';
@@ -117,8 +117,8 @@ export {
     ArchitectBuilderSchema,
     getArchitectOrBuilderSchema,
     requiredArchitectBuilderSchema,
-    RequiredURLs,
-    RequiredURLsSchema,
-    getRequiredURLsSchema,
-    requiredRequiredURLsSchema,
+    URLs,
+    URLsSchema,
+    getURLsSchema,
+    requiredURLsSchema,
 };


### PR DESCRIPTION
This PR delegates the 'Add'' button disabled/enabled state to Zod. Previously, we checked for the truthiness of local variables, without checking if they have been validated by Zod first, before enabling the 'Add' button.

This change has been made on Step 4_SiteNames, Step5_RecognitionDetails, Step8_ClassificationDetails and Step9_SiteDetails.

Additionally, it fixes some incorrectly named variables/functions in SiteDetailsSchema.