### PR TITLE
Brf/feat/1290 integrate component lab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ COPY ./arches_common ${ARCHES_COMMON_ROOT}
 WORKDIR ${ARCHES_ROOT}
 RUN pip install -e .[dev] && \
     pip install python-dotenv boto3==1.26 django-storages==1.13 oracledb html2text cffi redis && \
+    pip install django_vite && \
     pip install --upgrade cryptography PyJWT
 
 # Install BCGov Arches Common app

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ENV APP_ROOT=${WEB_ROOT}/${PROJECT_NAME}
 ENV ARCHES_ROOT=${WEB_ROOT}/arches
 # Arches Common App root
 ENV ARCHES_COMMON_ROOT=${WEB_ROOT}/arches_common
+# Arches Component Lab root
+ENV ARCHES_COMPONENT_LAB_ROOT=${WEB_ROOT}/arches-component-lab
 
 ENV WHEELS=/wheels
 ENV PYTHONUNBUFFERED=1
@@ -51,6 +53,7 @@ RUN rm -rf /root/.cache/pip/*
 # FIXME: ADD from github repository instead?
 COPY ./arches ${ARCHES_ROOT}
 COPY ./arches_common ${ARCHES_COMMON_ROOT}
+COPY ./arches-component-lab ${ARCHES_COMPONENT_LAB_ROOT}
 # From here, run commands from ARCHES_ROOT
 WORKDIR ${ARCHES_ROOT}
 RUN pip install -e .[dev] && \
@@ -60,6 +63,10 @@ RUN pip install -e .[dev] && \
 
 # Install BCGov Arches Common app
 WORKDIR ${ARCHES_COMMON_ROOT}
+RUN pip install -e .
+
+# Install Arches Component Lab
+WORKDIR ${ARCHES_COMPONENT_LAB_ROOT}
 RUN pip install -e .
 
 COPY ./bcrhp/docker/entrypoint.sh ${WEB_ROOT}/entrypoint.sh

--- a/bcrhp/media/js/arches_esm.js
+++ b/bcrhp/media/js/arches_esm.js
@@ -1,0 +1,121 @@
+import 'utils/set-csrf-token_esm';
+
+function removeTrailingCommaFromArray(string) {
+    return string.replace(/, *]*$/, ']');
+}
+
+function removeTrailingCommaFromObject(string) {
+    return string.replace(/,\s*}*$/, '}');
+}
+
+function convertToCamelCase(string) {
+    return string.replace(/-([a-z])/g, function (g) {
+        return g[1].toUpperCase();
+    });
+}
+
+const archesUrlHTMLObjects = document.querySelectorAll('.arches-urls');
+const parsedArchesUrls = {};
+for (let archesUrlHTMLObject of archesUrlHTMLObjects) {
+    for (let attribute of archesUrlHTMLObject.attributes) {
+        if (
+            attribute.specified &&
+            attribute.name !== 'style' &&
+            attribute.name !== 'class'
+        ) {
+            try {
+                let functionFromString = Function('return' + attribute.value);
+                let result = functionFromString();
+
+                if (!result) {
+                    result = '';
+                }
+                if (typeof result === 'object') {
+                    result = String(result);
+                }
+                parsedArchesUrls[attribute.name] = result;
+            } catch (error) {
+                parsedArchesUrls[attribute.name] = String(attribute.value);
+            }
+        }
+    }
+}
+
+const archesTranslationsHTMLObjects = document.querySelectorAll(
+    '.arches-translations',
+);
+const parsedArchesTranslations = {};
+for (let archesTranslationsHTMLObject of archesTranslationsHTMLObjects) {
+    for (let attribute of archesTranslationsHTMLObject.attributes) {
+        if (
+            attribute.specified &&
+            attribute.name !== 'style' &&
+            attribute.name !== 'class'
+        ) {
+            try {
+                let functionFromString = Function('return' + attribute.value);
+                let result = functionFromString();
+
+                if (!result) {
+                    result = '';
+                }
+
+                parsedArchesTranslations[convertToCamelCase(attribute.name)] =
+                    result;
+            } catch (error) {
+                parsedArchesTranslations[convertToCamelCase(attribute.name)] =
+                    JSON.parse(attribute.value);
+            }
+        }
+    }
+}
+
+const archesDataHTMLObjects = document.querySelectorAll('.arches-data');
+const parsedArchesData = {};
+for (let archesDataHTMLObject of archesDataHTMLObjects) {
+    for (let attribute of archesDataHTMLObject.attributes) {
+        if (
+            attribute.specified &&
+            attribute.name !== 'style' &&
+            attribute.name !== 'class'
+        ) {
+            const camelCaseName = convertToCamelCase(attribute.name);
+
+            try {
+                // first try parsing value
+                parsedArchesData[camelCaseName] = JSON.parse(attribute.value);
+            } catch (e) {
+                try {
+                    // if it fails, try removing trailing comma from object
+                    parsedArchesData[camelCaseName] = JSON.parse(
+                        removeTrailingCommaFromObject(attribute.value),
+                    );
+                } catch (e) {
+                    // if it fails, try removing trailing comma from array
+                    try {
+                        parsedArchesData[camelCaseName] = JSON.parse(
+                            removeTrailingCommaFromArray(attribute.value),
+                        );
+                    } catch (e) {
+                        // if it fails, coerce value to string
+                        parsedArchesData[camelCaseName] = JSON.parse(
+                            `"${attribute.value}"`,
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+const arches = { ...parsedArchesData };
+
+if (Object.keys(parsedArchesTranslations).length) {
+    arches['translations'] = parsedArchesTranslations;
+}
+
+if (Object.keys(parsedArchesUrls).length) {
+    arches['urls'] = parsedArchesUrls;
+}
+
+export default arches;

--- a/bcrhp/media/js/utils/set-csrf-token_esm.js
+++ b/bcrhp/media/js/utils/set-csrf-token_esm.js
@@ -1,0 +1,23 @@
+import $ from 'jquery';
+import Cookies from 'js-cookie';
+
+/**
+ * csrfSafeMethod - checks if the request method is CSRF safe (using regex)
+ * this function is called before every request made using jQuery, and
+ * the CSRF token is set accordingly
+ *
+ * @param  {string} method - request method name
+ * @return {boolean} true if the method is CSRF safe
+ */
+function csrfSafeMethod(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+
+$.ajaxSetup({
+    beforeSend: function(xhr, settings) {
+        if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+            xhr.setRequestHeader('X-CSRFToken', Cookies.get('csrftoken'));
+        }
+    }
+});

--- a/bcrhp/settings.py
+++ b/bcrhp/settings.py
@@ -55,7 +55,7 @@ SEARCH_COMPONENT_LOCATIONS.append("bcrhp.search_components")
 
 LOCALE_PATHS.insert(0, os.path.join(APP_ROOT, "locale"))
 
-FILE_TYPE_CHECKING = False
+FILE_TYPE_CHECKING = "strict"
 FILE_TYPES = [
     "bmp",
     "gif",
@@ -209,6 +209,7 @@ INSTALLED_APPS = (
     "django_vite",
     "storages",
     "bcrhp",
+    "arches_component_lab",
     "bcgov_arches_common",
 )
 INSTALLED_APPS += ("arches.app",)

--- a/bcrhp/src/bcrhp/App.vue
+++ b/bcrhp/src/bcrhp/App.vue
@@ -17,7 +17,11 @@ import {
 } from '@/bcgov_arches_common/constants.ts';
 
 import { routeNames } from '@/bcrhp/routes.ts';
-import { fetchUser, setUrlPrefix } from '@/bcgov_arches_common/api.ts';
+import {
+    fetchUser,
+    setUrlPrefix,
+    setUrlContextRoot,
+} from '@/bcgov_arches_common/api.ts';
 import PageHeader from '@/bcgov_arches_common/components/header/PageHeader.vue';
 import SideNav from '@/bcgov_arches_common/components/sidenav/SideNav.vue';
 
@@ -41,7 +45,8 @@ const toast = useToast();
 const { $gettext } = useGettext();
 
 // @todo - Get this from config
-setUrlPrefix('http://localhost/bcrhp');
+setUrlPrefix('http://localhost');
+setUrlContextRoot('/bcrhp');
 
 router.beforeEach(async (to, _from, next) => {
     try {

--- a/bcrhp/src/bcrhp/api.ts
+++ b/bcrhp/src/bcrhp/api.ts
@@ -1,6 +1,5 @@
 // import arches from 'arches';
 // import Cookies from 'js-cookie';
-import type { Ref } from 'vue';
 
 // @todo Initialize these from sever API call?
 export const arches = {
@@ -19,6 +18,8 @@ export const arches = {
         api_search_component_data: '/bcrhp/search_component_data/',
         api_tiles: '/bcrhp/api/tiles/',
         api_user_incomplete_workflows: '/bcrhp/api/user_incomplete_workflows',
+        legislative_acts: '/legislative_acts',
+        get_resource_search_url: '/resource_search_string_for_node',
     },
 };
 function getToken() {
@@ -29,57 +30,57 @@ function getToken() {
     return '';
 }
 
-export const login = async (username: string, password: string) => {
-    const response = await fetch(arches.urls.api_login, {
-        method: 'POST',
-        headers: { 'X-CSRFTOKEN': getToken() },
-        body: JSON.stringify({ username, password }),
-    });
-    const parsed = await response.json();
-    if (!response.ok) throw new Error(parsed.message || response.statusText);
-    return parsed;
-};
-
-export const logout = async () => {
-    const response = await fetch(arches.urls.api_logout, {
-        method: 'POST',
-        headers: { 'X-CSRFTOKEN': getToken() },
-    });
-    if (response.ok) return true;
-    const parsedError = await response.json();
-    throw new Error(parsedError.message || response.statusText);
-};
-
-export const fetchUser = async () => {
-    const response = await fetch(arches.urls.api_user);
-    const parsed = await response.json();
-    if (!response.ok) throw new Error(parsed.message || response.statusText);
-    return parsed;
-};
-
-export const fetchSearchResults = async (
-    searchTerm: string,
-    items: number,
-    page: number,
-) => {
-    const params = new URLSearchParams({
-        term: searchTerm,
-        items: items.toString(),
-        page: page.toString(),
-    });
-
-    const url = `${arches.urls.api_search}?${params.toString()}`;
-    const response = await fetch(url);
-    const parsed = await response.json();
-    if (!response.ok) throw new Error(parsed.message || response.statusText);
-    return parsed;
-};
-
-export const fetchConcepts = function (concept_id: string, concepts: Ref) {
-    const params = new URLSearchParams({
-        conceptid: concept_id,
-    });
-    fetch(`${arches.urls.paged_dropdown}?${params.toString()}`)
-        .then((response) => response.json())
-        .then((data) => (concepts.value = data.results));
-};
+// export const login = async (username: string, password: string) => {
+//     const response = await fetch(arches.urls.api_login, {
+//         method: 'POST',
+//         headers: { 'X-CSRFTOKEN': getToken() },
+//         body: JSON.stringify({ username, password }),
+//     });
+//     const parsed = await response.json();
+//     if (!response.ok) throw new Error(parsed.message || response.statusText);
+//     return parsed;
+// };
+//
+// export const logout = async () => {
+//     const response = await fetch(arches.urls.api_logout, {
+//         method: 'POST',
+//         headers: { 'X-CSRFTOKEN': getToken() },
+//     });
+//     if (response.ok) return true;
+//     const parsedError = await response.json();
+//     throw new Error(parsedError.message || response.statusText);
+// };
+//
+// export const fetchUser = async () => {
+//     const response = await fetch(arches.urls.api_user);
+//     const parsed = await response.json();
+//     if (!response.ok) throw new Error(parsed.message || response.statusText);
+//     return parsed;
+// };
+//
+// export const fetchSearchResults = async (
+//     searchTerm: string,
+//     items: number,
+//     page: number,
+// ) => {
+//     const params = new URLSearchParams({
+//         term: searchTerm,
+//         items: items.toString(),
+//         page: page.toString(),
+//     });
+//
+//     const url = `${arches.urls.api_search}?${params.toString()}`;
+//     const response = await fetch(url);
+//     const parsed = await response.json();
+//     if (!response.ok) throw new Error(parsed.message || response.statusText);
+//     return parsed;
+// };
+//
+// export const fetchConcepts = function (concept_id: string, concepts: Ref) {
+//     const params = new URLSearchParams({
+//         conceptid: concept_id,
+//     });
+//     fetch(`${arches.urls.paged_dropdown}?${params.toString()}`)
+//         .then((response) => response.json())
+//         .then((data) => (concepts.value = data.results));
+// };

--- a/bcrhp/src/bcrhp/api.ts
+++ b/bcrhp/src/bcrhp/api.ts
@@ -22,13 +22,6 @@ export const arches = {
         get_resource_search_url: '/resource_search_string_for_node',
     },
 };
-function getToken() {
-    // const token = Cookies.get('csrftoken');
-    // if (!token) {
-    //     throw new Error('Missing csrftoken');
-    // }
-    return '';
-}
 
 // export const login = async (username: string, password: string) => {
 //     const response = await fetch(arches.urls.api_login, {

--- a/bcrhp/src/bcrhp/declarations.d.ts
+++ b/bcrhp/src/bcrhp/declarations.d.ts
@@ -3,7 +3,7 @@
 
 import('@/arches/arches/declarations.d.ts');
 import('@/bcgov_arches_common/declarations.d.ts');
-import('@/arches-component-lab/declarations.d.ts');
+import('@/arches_component_lab/declarations.d.ts');
 
 declare module 'zod';
 declare module 'bcrhp';

--- a/bcrhp/src/bcrhp/declarations.d.ts
+++ b/bcrhp/src/bcrhp/declarations.d.ts
@@ -8,6 +8,7 @@ import('@/arches-component-lab/declarations.d.ts');
 declare module 'zod';
 declare module 'bcrhp';
 
+declare module '@/arches_component_lab';
 declare module '@/bcgov_arches_common';
 declare module '@/bcrhp';
 

--- a/bcrhp/src/bcrhp/declarations.d.ts
+++ b/bcrhp/src/bcrhp/declarations.d.ts
@@ -1,7 +1,7 @@
 // declare untyped modules that have been added to your project in `package.json`
 // Module homepage on npmjs.com uses logos "TS" or "DT" to indicate if typed
 
-import('@/arches/arches/declarations.d.ts');
+import('@/arches/declarations.d.ts');
 import('@/bcgov_arches_common/declarations.d.ts');
 import('@/arches_component_lab/declarations.d.ts');
 

--- a/bcrhp/src/bcrhp/declarations.d.ts
+++ b/bcrhp/src/bcrhp/declarations.d.ts
@@ -3,6 +3,7 @@
 
 import('@/arches/arches/declarations.d.ts');
 import('@/bcgov_arches_common/declarations.d.ts');
+import('@/arches-component-lab/declarations.d.ts');
 
 declare module 'zod';
 declare module 'bcrhp';

--- a/bcrhp/src/bcrhp/pages/steps/Step10_SupportingDocuments.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step10_SupportingDocuments.vue
@@ -18,8 +18,9 @@ const heritageSite: typeof HeritageSite = inject(
 ) as typeof HeritageSite;
 const ingredient = ref();
 
-const supportingDocumentsForm: Ref<FormInstance | null, FormInstance | null> =
-    useTemplateRef('supportingDocumentsForm');
+const supportingDocumentsForm: Ref<FormInstance | null> = useTemplateRef(
+    'supportingDocumentsForm',
+) as Ref<FormInstance | null>;
 const zodDocumentDescriptionResolver = zodResolver(
     HeritageSiteSchema.shape.documentDescription,
 );
@@ -28,7 +29,7 @@ const zodSubmissionNotesResolver = zodResolver(
 );
 
 const isValid = () => {
-    return supportingDocumentsForm.value.valid;
+    return supportingDocumentsForm.value?.valid;
 };
 
 const onAdvancedUpload = function () {};

--- a/bcrhp/src/bcrhp/pages/steps/Step10_SupportingDocuments.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step10_SupportingDocuments.vue
@@ -18,9 +18,8 @@ const heritageSite: typeof HeritageSite = inject(
 ) as typeof HeritageSite;
 const ingredient = ref();
 
-const supportingDocumentsForm: Ref<FormInstance> = useTemplateRef(
-    'supportingDocumentsForm',
-);
+const supportingDocumentsForm: Ref<FormInstance | null, FormInstance | null> =
+    useTemplateRef('supportingDocumentsForm');
 const zodDocumentDescriptionResolver = zodResolver(
     HeritageSiteSchema.shape.documentDescription,
 );

--- a/bcrhp/src/bcrhp/pages/steps/Step4_SiteNames.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step4_SiteNames.vue
@@ -25,7 +25,7 @@ const zodCommonNameResolver = zodResolver(HeritageSiteSchema.shape.commonName);
 const zodOtherNameResolver = zodResolver(HeritageSiteSchema.shape.otherName);
 
 const isValid = () => {
-    return siteNamesForm.value.valid;
+    return siteNamesForm.value?.valid;
 };
 
 const saveOtherName = function () {

--- a/bcrhp/src/bcrhp/pages/steps/Step4_SiteNames.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step4_SiteNames.vue
@@ -18,7 +18,9 @@ const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 const otherName = ref('');
 const otherNames = ref([] as Array<string>);
 
-const siteNamesForm: Ref<FormInstance> = useTemplateRef('siteNamesForm');
+const siteNamesForm: Ref<FormInstance> = useTemplateRef(
+    'siteNamesForm',
+) as Ref<FormInstance | null>;
 const zodCommonNameResolver = zodResolver(HeritageSiteSchema.shape.commonName);
 const zodOtherNameResolver = zodResolver(HeritageSiteSchema.shape.otherName);
 

--- a/bcrhp/src/bcrhp/pages/steps/Step4_SiteNames.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step4_SiteNames.vue
@@ -18,7 +18,7 @@ const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 const otherName = ref('');
 const otherNames = ref([] as Array<string>);
 
-const siteNamesForm: Ref<FormInstance> = useTemplateRef(
+const siteNamesForm: Ref<FormInstance | null> = useTemplateRef(
     'siteNamesForm',
 ) as Ref<FormInstance | null>;
 const zodCommonNameResolver = zodResolver(HeritageSiteSchema.shape.commonName);

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -34,11 +34,6 @@ const currentRecognitionDetails: typeof RecognitionDetails = ref(
 );
 const showInactiveHistoricActs = ref(false);
 
-const legislativeActOptions = ref([
-    { name: 'Legislative Act 1', code: 'legislative_act_1' },
-    { name: 'Legislative Act 2', code: 'legislative_act_2' },
-]);
-
 const designationDateResolver = zodResolver(
     RecognitionDetailsSchema.shape.designationDate,
 );

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -148,6 +148,7 @@ onMounted(() => {
                         :initial-value="[]"
                         graph-slug="heritage_site"
                         node-alias="legislative_act"
+                        :business-validator="legislativeActResolver"
                     />
                     <div class="inline-block">
                         <LabelledCheckboxInput

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -37,7 +37,7 @@ const showInactiveHistoricActs = ref(false);
 const designationDateResolver = zodResolver(
     RecognitionDetailsSchema.shape.designationDate,
 );
-const legislativeDateResolver = zodResolver(
+const legislativeActResolver = zodResolver(
     RecognitionDetailsSchema.shape.legislativeAct,
 );
 const referenceNumberResolver = zodResolver(
@@ -48,10 +48,10 @@ const totalRecognitionDetails = ref([] as Array<string>);
 const addOtherReferenceNumberDisabled = computed(
     () =>
         recognitionDetailsForm.value?.states?.designationDate?.pristine ||
-        recognitionDetailsForm.value?.states?.legislativeAct?.pristine ||
+        recognitionDetailsForm.value?.states?.legislative_act?.pristine ||
         recognitionDetailsForm.value?.states?.referenceNumber?.pristine ||
         recognitionDetailsForm.value?.states?.designationDate?.invalid ||
-        recognitionDetailsForm.value?.states?.legislativeAct?.invalid ||
+        recognitionDetailsForm.value?.states?.legislative_act?.invalid ||
         recognitionDetailsForm.value?.states?.referenceNumber?.invalid ||
         heritageSiteRef.value.recognitionDetails?.totalRecognitionDetails
             ?.length > 4,
@@ -73,7 +73,8 @@ const saveRecognitionDetails = function () {
                     day: 'numeric',
                 },
             ),
-        legislativeAct: currentRecognitionDetails.value.legislativeAct,
+        legislativeAct:
+            recognitionDetailsForm?.value.states.legislative_act.value[0],
         referenceNumber: currentRecognitionDetails.value.referenceNumber,
     });
 
@@ -132,50 +133,43 @@ onMounted(() => {
                     </div>
                 </LabelledInput>
             </FormField>
-            <FormField
-                :resolver="legislativeDateResolver"
-                name="legislativeAct"
+            <LabelledInput
+                label="Legislative Act"
+                hint="Designation or recognition type that applies to the site"
+                input-name="legislativeAct"
+                :error-message="$form.legislativeAct?.error?.message"
+                :required="true"
             >
-                <LabelledInput
-                    label="Legislative Act"
-                    hint="Designation or recognition type that applies to the site"
-                    input-name="legislativeAct"
-                    :error-message="$form.legislativeAct?.error?.message"
-                    :required="true"
-                >
-                    <div class="p-inputtext-fluid flex">
-                        <ResourceInstanceMultiSelectWidget
-                            id="legislativeAct"
-                            ref="legislativeActField"
-                            v-model="currentRecognitionDetails.legislativeAct"
-                            mode="edit"
-                            :initial-value="[]"
-                            graph-slug="heritage_site"
-                            node-alias="legislative_act"
-                            placeholder="Select Legislative Act"
-                        />
-                        <div class="inline-block">
-                            <LabelledCheckboxInput
-                                label="Historic Acts"
-                                hint="Show inactive acts"
-                                input-name="showInactiveHistoricActs"
-                            >
-                                <Checkbox
-                                    id="showInactiveHistoricActs"
-                                    ref="showInactiveHistoricActs"
-                                    :model-value="showInactiveHistoricActs"
-                                    aria-describedby="show-inactive-historic-acts-help"
-                                    aria-required="false"
-                                    class="inline-block"
-                                    fluid
-                                    binary
-                                    small
-                                />
-                            </LabelledCheckboxInput>
-                        </div>
+                <div class="p-inputtext-fluid flex">
+                    <ResourceInstanceMultiSelectWidget
+                        ref="legislativeActField"
+                        :show-label="false"
+                        mode="edit"
+                        :initial-value="[]"
+                        graph-slug="heritage_site"
+                        node-alias="legislative_act"
+                    />
+                    <div class="inline-block">
+                        <LabelledCheckboxInput
+                            label="Historic Acts"
+                            hint="Show inactive acts"
+                            input-name="showInactiveHistoricActs"
+                        >
+                            <Checkbox
+                                id="showInactiveHistoricActs"
+                                ref="showInactiveHistoricActs"
+                                :model-value="showInactiveHistoricActs"
+                                aria-describedby="show-inactive-historic-acts-help"
+                                aria-required="false"
+                                class="inline-block"
+                                fluid
+                                binary
+                                small
+                            />
+                        </LabelledCheckboxInput>
                     </div>
-                </LabelledInput>
-            </FormField>
+                </div>
+            </LabelledInput>
             <FormField
                 :resolver="referenceNumberResolver"
                 name="referenceNumber"

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -58,7 +58,7 @@ const addOtherReferenceNumberDisabled = computed(
 );
 
 const isValid = () => {
-    return recognitionDetailsForm.value.valid;
+    return recognitionDetailsForm.value?.valid;
 };
 
 const saveRecognitionDetails = function () {
@@ -74,7 +74,7 @@ const saveRecognitionDetails = function () {
                 },
             ),
         legislativeAct:
-            recognitionDetailsForm?.value.states.legislative_act.value[0],
+            recognitionDetailsForm?.value?.states.legislative_act.value[0],
         referenceNumber: currentRecognitionDetails.value.referenceNumber,
     });
 

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -23,7 +23,7 @@ import { DATE_FORMAT } from '@/bcrhp/constants.ts';
 
 const recognitionDetailsForm: Ref<FormInstance> = useTemplateRef(
     'recognitionDetailsRef',
-);
+) as Ref<FormInstance | null>;
 
 const heritageSite: typeof HeritageSite = inject(
     'heritageSite',

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -7,8 +7,8 @@ import InputText from 'primevue/inputtext';
 import Checkbox from 'primevue/checkbox';
 import Button from 'primevue/button';
 import DatePicker from 'primevue/datepicker';
-import Select from 'primevue/select';
 import { Form, FormField, type FormInstance } from '@primevue/forms';
+import ResourceInstanceMultiSelectWidget from '@/arches_component_lab/widgets/ResourceInstanceMultiSelectWidget/ResourceInstanceMultiSelectWidget.vue';
 import MultiValuePlaceholder from '@/bcgov_arches_common/components/multiValuePlaceholder/MultiValuePlaceholder.vue';
 import LabelledInput from '@/bcgov_arches_common/components/labelledinput/LabelledInput.vue';
 import LabelledCheckboxInput from '@/bcgov_arches_common/components/labelledinput/LabelledCheckbox.vue';
@@ -149,19 +149,15 @@ onMounted(() => {
                     :required="true"
                 >
                     <div class="p-inputtext-fluid flex">
-                        <Select
+                        <ResourceInstanceMultiSelectWidget
                             id="legislativeAct"
                             ref="legislativeActField"
                             v-model="currentRecognitionDetails.legislativeAct"
-                            name="legislativeAct"
-                            optionValue="code"
-                            optionLabel="name"
+                            mode="edit"
+                            :initial-value="[]"
+                            graph-slug="heritage_site"
+                            node-alias="legislative_act"
                             placeholder="Select Legislative Act"
-                            :options="legislativeActOptions"
-                            aria-describedby="legislative-act-help"
-                            aria-required="true"
-                            fluid
-                            class="w-full md:w-14rem"
                         />
                         <div class="inline-block">
                             <LabelledCheckboxInput

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -21,7 +21,7 @@ import {
 } from '@/bcrhp/schema/RecognitionDetailsSchema.ts';
 import { DATE_FORMAT } from '@/bcrhp/constants.ts';
 
-const recognitionDetailsForm: Ref<FormInstance> = useTemplateRef(
+const recognitionDetailsForm: Ref<FormInstance | null> = useTemplateRef(
     'recognitionDetailsRef',
 ) as Ref<FormInstance | null>;
 

--- a/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
@@ -31,7 +31,7 @@ const zodDocumentLocationResolver = zodResolver(
 );
 
 const isValid = () => {
-    return statementOfSignificanceForm.value.valid;
+    return statementOfSignificanceForm.value?.valid;
 };
 
 defineExpose({ isValid });

--- a/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
@@ -16,7 +16,7 @@ const heritageSite: typeof HeritageSite = inject(
 
 const statementOfSignificanceForm: Ref<FormInstance> = useTemplateRef(
     'statementOfSignificanceForm',
-);
+) as Ref<FormInstance | null>;
 const zodDescriptionResolver = zodResolver(
     StatementOfSignificanceSchema.shape.description,
 );

--- a/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step6_SOS.vue
@@ -14,7 +14,7 @@ const heritageSite: typeof HeritageSite = inject(
     'heritageSite',
 ) as typeof HeritageSite;
 
-const statementOfSignificanceForm: Ref<FormInstance> = useTemplateRef(
+const statementOfSignificanceForm: Ref<FormInstance | null> = useTemplateRef(
     'statementOfSignificanceForm',
 ) as Ref<FormInstance | null>;
 const zodDescriptionResolver = zodResolver(

--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -25,7 +25,7 @@ const imageDate = ref();
 currentSiteImage.value.imageTypes = [];
 heritageSite.value.siteImages[currentSiteImage.value.id] = currentSiteImage;
 
-const siteImageForm: Ref<FormInstance> = useTemplateRef(
+const siteImageForm: Ref<FormInstance | null> = useTemplateRef(
     'siteImageForm',
 ) as Ref<FormInstance | null>;
 const zodImageTypeResolver = zodResolver(SiteImagesSchema.shape.imageType);

--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -25,7 +25,9 @@ const imageDate = ref();
 currentSiteImage.value.imageTypes = [];
 heritageSite.value.siteImages[currentSiteImage.value.id] = currentSiteImage;
 
-const siteImageForm: Ref<FormInstance> = useTemplateRef('siteImageForm');
+const siteImageForm: Ref<FormInstance> = useTemplateRef(
+    'siteImageForm',
+) as Ref<FormInstance | null>;
 const zodImageTypeResolver = zodResolver(SiteImagesSchema.shape.imageType);
 const zodImageViewResolver = zodResolver(SiteImagesSchema.shape.imageView);
 const zodImageFeaturesResolver = zodResolver(

--- a/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step7_SiteImages.vue
@@ -43,7 +43,7 @@ const zodPhotographerResolver = zodResolver(
 const zodCopyrightResolver = zodResolver(SiteImagesSchema.shape.copyright);
 
 const isValid = () => {
-    return siteImageForm.value.valid;
+    return siteImageForm.value?.valid;
 };
 
 const onImageUpload = function () {};

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -28,7 +28,7 @@ const heritageSite: typeof HeritageSite = inject(
 ) as typeof HeritageSite;
 const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 
-const siteClassificationForm: Ref<FormInstance> = useTemplateRef(
+const siteClassificationForm: Ref<FormInstance | null> = useTemplateRef(
     'siteClassificationForm',
 ) as Ref<FormInstance | null>;
 const currentHeritageClass: typeof HeritageClass = ref(

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -62,7 +62,7 @@ const zodHeritageThemeResolver = zodResolver(
 );
 
 const isValid = () => {
-    return siteClassificationForm.value.valid;
+    return siteClassificationForm.value?.valid;
 };
 
 const addOtherHeritageClassDisabled = computed(

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -30,7 +30,7 @@ const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 
 const siteClassificationForm: Ref<FormInstance> = useTemplateRef(
     'siteClassificationForm',
-);
+) as Ref<FormInstance | null>;
 const currentHeritageClass: typeof HeritageClass = ref(
     getHeritageClassSchema(),
 );

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -59,7 +59,7 @@ const zodLinkTextResolver = zodResolver(URLsSchema.shape.linkText);
 const zodURLResolver = zodResolver(URLsSchema.shape.url);
 
 const isValid = () => {
-    return siteDetailsForm.value.valid;
+    return siteDetailsForm.value?.valid;
 };
 
 const addChronologyDisabled = computed(

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -35,7 +35,7 @@ const currentURL = ref(getURLsSchema());
 const architectsOrBuilders = ref([] as Array<string>);
 const urls = ref([] as Array<string>);
 
-const siteDetailsForm: Ref<FormInstance> = useTemplateRef(
+const siteDetailsForm: Ref<FormInstance | null> = useTemplateRef(
     'siteDetailsForm',
 ) as Ref<FormInstance | null>;
 const zodEventTypeResolver = zodResolver(ChronologySchema.shape.eventType);

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -35,7 +35,9 @@ const currentURL = ref(getURLsSchema());
 const architectsOrBuilders = ref([] as Array<string>);
 const urls = ref([] as Array<string>);
 
-const siteDetailsForm: Ref<FormInstance> = useTemplateRef('siteDetailsForm');
+const siteDetailsForm: Ref<FormInstance> = useTemplateRef(
+    'siteDetailsForm',
+) as Ref<FormInstance | null>;
 const zodEventTypeResolver = zodResolver(ChronologySchema.shape.eventType);
 const zodStartYearResolver = zodResolver(ChronologySchema.shape.startYear);
 const zodEndYearResolver = zodResolver(ChronologySchema.shape.endYear);

--- a/bcrhp/templates/bcrhp/root_vue_dev.htm
+++ b/bcrhp/templates/bcrhp/root_vue_dev.htm
@@ -54,103 +54,14 @@
     {% vite_asset '/bcrhp/static/build/js/views/root_vue.js'%}
     <div id="bcrhp-mounting-point" class="bcgov-vue-mounting-point"></div>
 
-    <div class='arches-urls' root="/bcrhp/" home="/bcrhp/index.htm" media="/bcrhp/static/" rdm="/bcrhp/rdm/"
-        uploadedfiles="/files/" url_subpath="" concept_tree="/bcrhp/concepts/tree/"
-        concept="/bcrhp/concepts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" concept_search="/bcrhp/concepts/search"
-        concept_value="/bcrhp/conceptvalue/"
-        concept_manage_parents="/bcrhp/concepts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/manage_parents/"
-        concept_make_collection="/bcrhp/concepts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/make_collection/"
-        change_password="/bcrhp/auth/password"
-        export_concept="/bcrhp/concepts/export/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-        export_concept_collections="/bcrhp/concepts/export/collections"
-        get_concept_collections="/bcrhp/concepts/collections" dropdown="/bcrhp/concepts/dropdown"
-        paged_dropdown="/bcrhp/concepts/paged_dropdown" get_pref_label="/bcrhp/concepts/get_pref_label"
-        from_sparql_endpoint="/bcrhp/concepts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/from_sparql_endpoint"
-        search_sparql_endpoint="/bcrhp/concepts/search_sparql_endpoint"
-        confirm_delete="/bcrhp/concepts/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/confirm_delete/"
-        search_home="/bcrhp/search" search_terms="/bcrhp/search/terms" search_results="/bcrhp/search/resources"
-        export_results="/bcrhp/search/export_results" get_export_file="/bcrhp/search/get_export_file"
-        buffer="/bcrhp/buffer/" config="/bcrhp/settings/" node="/bcrhp/node/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-        graph_nodes='(graphid)=>{return "/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/nodes".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        nodegroup="/bcrhp/nodegroup/" node_layer="/bcrhp/node_layer/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-        graph='"/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        graph_designer='(graphid)=>{return "/bcrhp/graph_designer/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        graph_settings='(graphid)=>{return "/bcrhp/graph_settings/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        get_notifications="/bcrhp/notifications" dismiss_notifications="/bcrhp/notifications/dismiss"
-        get_notification_types="/bcrhp/notifications/get_types"
-        update_notification_types="/bcrhp/notifications/update_types" card="/bcrhp/card/"
-        reorder_cards="/bcrhp/reorder_cards/" resource="/bcrhp/resource"
-        resource_editor='"/bcrhp/resource/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        resource_copy='"/bcrhp/resource/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/copy".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        resource_report='"/bcrhp/report/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        resource_edit_log='"/bcrhp/resource/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/history".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        get_resource_edit_log='(graphid)=>{return "/bcrhp/resource/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/history".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        resource_data='"/bcrhp/resource/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/data/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace(/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/g, "")'
-        resource_cards='"/bcrhp/resource/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/cards".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        related_resources='"/bcrhp/resource/related/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        resource_descriptors='"/bcrhp/resource/descriptors/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        resource_tiles="/bcrhp/resource/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/tiles" tile="/bcrhp/tile"
-        reorder_tiles="/bcrhp/tiles/reorder_tiles" reorder_nodes="/bcrhp/graph/reorder_nodes"
-        delete_provisional_tile="/bcrhp/tiles/delete_provisional_tile" edit_history="/bcrhp/resource/history"
-        tile_history="/bcrhp/tiles/tile_history" download_files="/bcrhp/tiles/download_files"
-        apply_functions='"/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/apply_functions".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        remove_functions='"/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/remove_functions".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        time_wheel_config="/bcrhp/search/time_wheel_config"
-        two_factor_authentication_reset="/bcrhp/two-factor-authentication-reset"
-        reindex="/bcrhp/admin/reindex/resources" permission_data="/bcrhp/graph/permissions"
-        resource_permission_data="/bcrhp/resource/permissions"
-        permission_manager_data="/bcrhp/graph/permissions/permission_manager_data"
-        clear_user_permission_cache="/bcrhp/clear-user-permission-cache" get_user_names="/bcrhp/user/get_user_names"
-        feature_popup_content="/bcrhp/feature_popup_content"
-        related_resource_candidates="/bcrhp/resource/related/candidates"
-        relatable_resources="/bcrhp/resource/related/relatable" languages="/bcrhp/language/"
-        get_domain_connections='(graphid)=>{return "/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/get_domain_connections".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        clone_graph='(graphid)=>{return "/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/clone".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        export_graph='(graphid)=>{return "/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/export".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        publish_graph='(graphid)=>{return "/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/publish".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        unpublish_graph='(graphid)=>{return "/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/unpublish".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        delete_graph='(graphid)=>{return "/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/delete".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        delete_instances='(graphid)=>{return "/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/delete_instances".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        export_mapping_file='(graphid)=>{return "/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/export_mapping_file".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        add_resource='(graphid)=>{return "/bcrhp/add-resource/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        function_manager='(graphid)=>{return "/bcrhp/graph/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/function_manager".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", graphid)}'
-        plugin='(pluginid)=>{return "/bcrhp/plugins/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", pluginid)}'
-        workflow_history='"/bcrhp/workflow_history/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        transaction_reverse='(transactionid)=> {return "/bcrhp/transaction/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/reverse".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", transactionid)}'
-        mvt='(nodeid)=>{return decodeURI("/bcrhp/mvt/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/%7Bz%7D/%7Bx%7D/%7By%7D.pbf").replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", nodeid)}'
-        help_template="/bcrhp/help-templates"
-        api_plugins='"/bcrhp/api/plugins/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        graphs_api='"/bcrhp/graphs/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        api_card='"/bcrhp/cards/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "")'
-        api_tiles='(tileid)=>{
-        return "/bcrhp/api/tiles/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", tileid);
-    }' api_nodegroup='(nodegroupid)=>{
-        return "/bcrhp/api/nodegroup/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", nodegroupid);
-    }' api_nodes='(nodeid)=>{
-        return "/bcrhp/api/nodes/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", nodeid);
-    }' api_node_value="/bcrhp/api/node_value/"
-        api_resource_report='(resourceid)=>{return "/bcrhp/api/resource_report/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", resourceid)}'
-        api_bulk_resource_report="/bcrhp/api/bulk_resource_report"
-        api_bulk_disambiguated_resource_instance="/bcrhp/api/bulk_disambiguated_resource_instance"
-        api_resources='(resourceid)=>{return "/bcrhp/resources/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".replace("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", resourceid)}'
-        api_search_component_data='"/bcrhp/search_component_data/aaaa".replace("aaaa", "")'
-        api_user_incomplete_workflows="/bcrhp/api/user_incomplete_workflows"
-        api_get_frontend_i18n_data="/bcrhp/api/get_frontend_i18n_data" geojson="/bcrhp/geojson" icons="/bcrhp/icons"
-        ontology_properties="/bcrhp/ontology_properties" iiifmanifest="/bcrhp/iiifmanifest"
-        manifest_manager="/bcrhp/image-service-manager" etl_manager="/bcrhp/etl-manager"
-        iiifannotations="/bcrhp/iiifannotations" iiifannotationnodes="/bcrhp/iiifannotationnodes"
-        validatejson='"/bcrhp/validate/aaaa".replace("aaaa", "")' get_dsl="/bcrhp/search/get_dsl"
-        transform_edtf_for_tile="/bcrhp/transform-edtf-for-tile" api_get_nodegroup_tree="/bcrhp/api/get_nodegroup_tree">
-    </div>
+    {% block arches_modules %}
+        {% include "arches_urls.htm" %}
+    {% endblock arches_modules %}
 
     <div class="arches-urls" api_user="/bcrhp/api/user/" user_profile_manager="/bcrhp/user"
         dashboard="/bcrhp/submissions/">
     </div>
 
-
-    <div class="arches-urls" api_user="/bcrhp/api/user/" user_profile_manager="/bcrhp/user"
-        dashboard="/bcrhp/submissions/">
-    </div>
 </body>
 
 </html>

--- a/bcrhp/urls.py
+++ b/bcrhp/urls.py
@@ -115,8 +115,9 @@ urlpatterns = [
         bcrhp_export_results,
         name="export_results",
     ),
-    common_url_resolver,
-    bc_url_resolver,
+    re_path(r'^bcrhp/', include('bcgov_arches_common.urls')),
+    path('bcrhp/', include("arches_component_lab.urls")),
+    path('bcrhp/', include("arches.urls")),
 ]
 
 # # Ensure Arches core urls are superseded by project-level urls

--- a/bcrhp/urls.py
+++ b/bcrhp/urls.py
@@ -24,6 +24,7 @@ def bc_path_prefix(path):
         new_path = path_prefix_re.sub(r"\1%s\2", path)
         return new_path % settings.BCGOV_PROXY_PREFIX
 
+
 urlpatterns = [
     re_path(
         bc_path_prefix(r"^submissions/"), BcrhpRootView.as_view(), name="submissions"
@@ -96,9 +97,9 @@ urlpatterns = [
         bcrhp_export_results,
         name="export_results",
     ),
-    re_path(r'^bcrhp/', include('bcgov_arches_common.urls')),
-    path('bcrhp/', include("arches_component_lab.urls")),
-    path('bcrhp/', include("arches.urls")),
+    re_path(r"^bcrhp/", include("bcgov_arches_common.urls")),
+    path("bcrhp/", include("arches_component_lab.urls")),
+    path("bcrhp/", include("arches.urls")),
 ]
 
 # # Ensure Arches core urls are superseded by project-level urls

--- a/bcrhp/urls.py
+++ b/bcrhp/urls.py
@@ -2,7 +2,6 @@ from django.urls import include, path, re_path
 from django.conf import settings
 from django.conf.urls.static import static
 from django.conf.urls.i18n import i18n_patterns
-from django.urls.resolvers import RegexPattern
 from bcrhp.views.api import BordenNumber, MVT, LegislativeAct, UserProfile
 from bcrhp.views.crhp import CRHPXmlExport
 from bcrhp.views.search import export_results as bcrhp_export_results
@@ -24,24 +23,6 @@ def bc_path_prefix(path):
     else:
         new_path = path_prefix_re.sub(r"\1%s\2", path)
         return new_path % settings.BCGOV_PROXY_PREFIX
-
-
-class BCRegexPattern(RegexPattern):
-    def __init__(self, regexpattern):
-        super().__init__(
-            bc_path_prefix(regexpattern.regex.pattern),
-            regexpattern.name,
-            regexpattern._is_endpoint,
-        )
-
-
-common_url_resolver = re_path(r"^", include("bcgov_arches_common.urls"))
-bc_url_resolver = re_path((r"^"), include("arches.urls"))
-
-for pattern in bc_url_resolver.url_patterns + common_url_resolver.url_patterns:
-    # print("Before: %s" % pattern.pattern)
-    pattern.pattern = BCRegexPattern(pattern.pattern)
-    # print("After: %s" % pattern.pattern)
 
 urlpatterns = [
     re_path(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ../arches/:/web_root/arches
       - ./:/web_root/bcrhp
       - ../arches_common/:/web_root/arches_common
+      - ../arches-component-lab/:/web_root/arches-component-lab
     env_file:
       - ./docker/env_file.env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,22 +23,22 @@ services:
     stdin_open: true
     tty: true
 
-  bcrhp-webpack:
-    container_name: bcrhp-webpack7-6
-    image: bcgov/bcrhp-webpack7-6
-    build:
-      context: ..
-      dockerfile: bcrhp/docker/webpack/Dockerfile
-    command: run_webpack
-    volumes:
-      - ../arches/:/web_root/arches
-      - ./:/web_root/bcrhp
-    env_file:
-      - ./docker/webpack/env_file.env
-    ports:
-      - 8022:8021
-    stdin_open: true
-    tty: true
+#   bcrhp-webpack:
+#     container_name: bcrhp-webpack7-6
+#     image: bcgov/bcrhp-webpack7-6
+#     build:
+#       context: ..
+#       dockerfile: bcrhp/docker/webpack/Dockerfile
+#     command: run_webpack
+#     volumes:
+#       - ../arches/:/web_root/arches
+#       - ./:/web_root/bcrhp
+#     env_file:
+#       - ./docker/webpack/env_file.env
+#     ports:
+#       - 8022:8021
+#     stdin_open: true
+#     tty: true
 
 networks:
   default:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,56 @@
+Developing in Docker instance.
+
+
+1. Change the following lines in pyproject.json:
+```shell
+    "arches==7.6.9",
+    "bcgov_arches_common @ git+https://github.com/bcgov/arches_common@release/1.1.0_add_vue_components",
+    "arches-component-lab==0.0.1",
+```
+
+to 
+```shell
+    "arches @ file:../arches",
+    "bcgov_arches_common @ file:../arches_common",
+    "arches-component-lab @ file:../arches-component-lab",
+```
+
+2. Change the following lines in package.json:
+```shell
+        "arches-component-lab": "latest",
+        "bcgov_arches_common": "github:bcgov/arches_common#release/1.1.0_add_vue_components",
+```
+to
+```shell
+        "arches-component-lab": "file:../arches-component-lab",
+        "bcgov_arches_common": "file:../arches_common",
+```
+4. Update settings.py to run using Vite. Change the following line
+```python
+DJANGO_VITE = {
+    "default": {
+        "dev_mode": False,  # <---- This value
+        "static_url_prefix": "/",
+    }
+}
+```
+to
+```python
+DJANGO_VITE = {
+    "default": {
+        "dev_mode": True,# <---- This value
+        "static_url_prefix": "/",
+    }
+}
+```
+
+5. Start the container from `bcrhp` (directory with the `docker-compose.yml` file:
+`docker compose up`
+
+6. Connect to docker container and build the frontend components:
+```shell
+docker exec -it bcrhp7-6 /bin/bash
+python3.11 manage.py check
+npm run build_development
+npm run vite_dev
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,13 +1,18 @@
 Developing in Docker instance.
 
+1. Branches:
+BCRHP: `brf/feat/1290_integrate_component_lab`
+BCGov Arches Common: `brf/feat/update_api`
+Arches Component Lab: `main`
+Arches: `stable/7.6.9_bcgov`
 
-1. Change the following lines in pyproject.json:
+
+2. Change the following lines in pyproject.json:
 ```shell
     "arches==7.6.9",
     "bcgov_arches_common @ git+https://github.com/bcgov/arches_common@release/1.1.0_add_vue_components",
     "arches-component-lab==0.0.1",
 ```
-
 to 
 ```shell
     "arches @ file:../arches",
@@ -15,7 +20,7 @@ to
     "arches-component-lab @ file:../arches-component-lab",
 ```
 
-2. Change the following lines in package.json:
+3. Change the following lines in package.json:
 ```shell
         "arches-component-lab": "latest",
         "bcgov_arches_common": "github:bcgov/arches_common#release/1.1.0_add_vue_components",
@@ -25,7 +30,7 @@ to
         "arches-component-lab": "file:../arches-component-lab",
         "bcgov_arches_common": "file:../arches_common",
 ```
-4. Update settings.py to run using Vite. Change the following line
+4. Update `bcrhp/settings.py` to run using Vite. Change the following line
 ```python
 DJANGO_VITE = {
     "default": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "@vitejs/plugin-vue": "^5.2.1",
         "@vue/cli": "^5.0.8",
         "arches": "github:bcgov/arches#v7.6.9_bcgov",
+        "arches-component-lab": "0.0.1",
         "bcgov_arches_common": "github:bcgov/arches_common#release/1.1.0_add_vue_components",
         "ckeditor5": "44.2.0",
         "js-cookie": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@vitejs/plugin-vue": "^5.2.1",
         "@vue/cli": "^5.0.8",
         "arches": "github:bcgov/arches#v7.6.9_bcgov",
-        "arches-component-lab": "0.0.1",
+        "arches-component-lab": "github:archesproject/arches-component-lab#main",
         "bcgov_arches_common": "github:bcgov/arches_common#release/1.1.0_add_vue_components",
         "ckeditor5": "44.2.0",
         "js-cookie": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@vue/cli": "^5.0.8",
         "arches": "github:bcgov/arches#v7.6.9_bcgov",
         "arches-component-lab": "github:archesproject/arches-component-lab#main",
-        "bcgov_arches_common": "github:bcgov/arches_common#release/1.1.0_add_vue_components",
+        "bcgov_arches_common": "github:bcgov/arches_common#brf/feat/update_api",
         "ckeditor5": "44.2.0",
         "js-cookie": "^2.1.1",
         "primevue": "^4.2.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "arches==7.6.9",
-    "bcgov_arches_common @ git+https://github.com/bcgov/arches_common@release/1.1.0_add_vue_components",
+    "bcgov_arches_common @ git+https://github.com/bcgov/arches_common@brf/feat/update_api",
     "arches-component-lab @ git+https://github.com/archesproject/arches-component-lab@main",
     "django-storages==1.13",
     "python-dotenv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ requires-python = ">=3.10"
 dependencies = [
     "arches==7.6.9",
     "bcgov_arches_common @ git+https://github.com/bcgov/arches_common@release/1.1.0_add_vue_components",
+    "arches-component-lab==0.0.1",
     "django-storages==1.13",
     "python-dotenv",
     "html2text",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.10"
 dependencies = [
     "arches==7.6.9",
     "bcgov_arches_common @ git+https://github.com/bcgov/arches_common@release/1.1.0_add_vue_components",
-    "arches-component-lab @ git+https://github:archesproject/arches-component-lab@main",
+    "arches-component-lab @ git+https://github.com/archesproject/arches-component-lab@main",
     "django-storages==1.13",
     "python-dotenv",
     "html2text",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.10"
 dependencies = [
     "arches==7.6.9",
     "bcgov_arches_common @ git+https://github.com/bcgov/arches_common@release/1.1.0_add_vue_components",
-    "arches-component-lab==0.0.1",
+    "arches-component-lab @ git+https://github:archesproject/arches-component-lab@main",
     "django-storages==1.13",
     "python-dotenv",
     "html2text",

--- a/tests/github_settings.py
+++ b/tests/github_settings.py
@@ -206,6 +206,7 @@ INSTALLED_APPS = (
     # "silk",
     "storages",
     "bcrhp",
+    "arches_component_lab",
     "bcgov_arches_common",
 )
 INSTALLED_APPS += ("arches.app",)

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -84,6 +84,15 @@ export default defineConfig({
                 replacement: path.resolve(path.join(appRoot, 'node_modules')),
             },
             {
+                find: '@/arches_component_lab',
+                replacement: path.resolve(
+                    path.join(
+                        __dirname,
+                        './node_modules/arches-component-lab/arches_component_lab/src/arches_component_lab',
+                    ),
+                ),
+            },
+            {
                 find: '@/arches',
                 replacement: path.resolve(
                     path.join(
@@ -97,6 +106,57 @@ export default defineConfig({
                     ),
                 ),
             },
+            // This is to override the arches core AMD module with an ESM version
+            {
+                find: 'arches',
+                replacement: path.resolve(
+                    path.join(appRoot, 'bcrhp', 'media', 'js', 'arches_esm'),
+                ),
+            },
+            {
+                find: 'utils/set-csrf-token_esm',
+                replacement: path.resolve(
+                    path.join(
+                        appRoot,
+                        'bcrhp',
+                        'media',
+                        'js',
+                        'utils',
+                        'set-csrf-token_esm',
+                    ),
+                ),
+            },
+            // {
+            //     find: 'arches2',
+            //     replacement: path.resolve(
+            //         path.join(
+            //             appRoot,
+            //             '..',
+            //             'arches',
+            //             'arches',
+            //             'app',
+            //             'media',
+            //             'js',
+            //             'arches_esm',
+            //         ),
+            //     ),
+            // },
+            // {
+            //     find: 'utils/set-csrf-token2',
+            //     replacement: path.resolve(
+            //         path.join(
+            //             appRoot,
+            //             '..',
+            //             'arches',
+            //             'arches',
+            //             'app',
+            //             'media',
+            //             'js',
+            //             'utils',
+            //             'set-csrf-token2',
+            //         ),
+            //     ),
+            // },
             {
                 find: '@/bcgov_arches_common',
                 replacement: path.resolve(
@@ -106,7 +166,6 @@ export default defineConfig({
                     ),
                 ),
             },
-
             {
                 find: '@/bcrhp',
                 replacement: path.resolve(
@@ -138,6 +197,11 @@ export default defineConfig({
         },
         deps: {
             inline: ['node', 'arches'],
+        },
+        // Force all API calls back to the Arches Dev server
+        proxy: {
+            '/bcrhp/arches-component-lab/api': 'http://localhost:80',
+            '/bcrhp/api': 'http://localhost:80',
         },
         fs: {
             allow: [


### PR DESCRIPTION
This PR does the following:
1. integrates the arches component lab so that widgets there can start to be reused here, and future development can be provided back to Arches Core.
2. Creates an esm version of the `arches.js` & `set-csrf-token.js` to allow the component lab to be used w/ Vite
3. fixes some typescript errors that have crept into the code
4. Simplifies the URL prefix implementation
5. Adds an initial readme to perform a clean docker build 

This should be tested and merged in alongside this Arches Common PR: https://github.com/bcgov/arches_common/pull/23/files