### PR TITLE
Ensure that the 'Next' button has the correct label/fix CSS on Step3

### DIFF
--- a/bcrhp/src/bcrhp/pages/NewSite.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite.vue
@@ -276,7 +276,7 @@ const showDebug = ref(false);
                                 <StepperNavigation
                                     :step-number="6"
                                     :validate-fn="isValid"
-                                    next-label="Submit"
+                                    next-label="Next"
                                     @next-click="activateCallback(7)"
                                     @previous-click="activateCallback(5)"
                                 >
@@ -299,7 +299,7 @@ const showDebug = ref(false);
                             <SiteImages ref="step7"></SiteImages>
                             <div class="">
                                 <StepperNavigation
-                                    :step-number="6"
+                                    :step-number="7"
                                     :validate-fn="isValid"
                                     next-label="Next"
                                     @next-click="activateCallback(8)"
@@ -322,7 +322,7 @@ const showDebug = ref(false);
                             ></SiteClassification>
                             <div class="">
                                 <StepperNavigation
-                                    :step-number="6"
+                                    :step-number="8"
                                     :validate-fn="isValid"
                                     next-label="Next"
                                     @next-click="activateCallback(9)"
@@ -341,7 +341,7 @@ const showDebug = ref(false);
                             <SiteDetails ref="step9"></SiteDetails>
                             <div class="">
                                 <StepperNavigation
-                                    :step-number="6"
+                                    :step-number="9"
                                     :validate-fn="isValid"
                                     next-label="Next"
                                     @next-click="activateCallback(10)"
@@ -364,7 +364,7 @@ const showDebug = ref(false);
                             ></SupportingDocuments>
                             <div class="">
                                 <StepperNavigation
-                                    :step-number="6"
+                                    :step-number="10"
                                     :validate-fn="isValid"
                                     next-label="Next"
                                     @next-click="activateCallback(11)"
@@ -383,7 +383,7 @@ const showDebug = ref(false);
                             <ReviewSubmission ref="step11"></ReviewSubmission>
                             <div class="">
                                 <StepperNavigation
-                                    :step-number="6"
+                                    :step-number="11"
                                     :validate-fn="isValid"
                                     next-label="Submit"
                                     @next-click="activateCallback(12)"
@@ -400,7 +400,7 @@ const showDebug = ref(false);
                             </div>
                             <div class="">
                                 <StepperNavigation
-                                    :step-number="7"
+                                    :step-number="12"
                                     :validate-fn="isValid"
                                     :show-previous="false"
                                     next-label="Print"

--- a/bcrhp/src/bcrhp/pages/steps/Step3_SpatialLocation.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step3_SpatialLocation.vue
@@ -82,17 +82,17 @@ defineExpose({ isValid });
 onMounted(() => {});
 </script>
 <template>
-    <div class="flex flex-col container">
+    <div class="flex flex-col container-width">
         <div style="display: none">Child {{ currentCivicAddress }}</div>
         <FieldSet
             id="siteBoundaryFieldSet"
             legend="Site Boundary"
-            style="width: 45%; display: inline-block"
+            style="width: 55%; display: inline-block"
         >
-            <div class="flex flex-row container">
+            <div class="flex flex-row container-width">
                 <div>
                     <LabelledCheckboxInput
-                        label="Site Boundary icorrect"
+                        label="Site Boundary incorrect"
                         hint="Update the geometry"
                         input-name="hasCivicAddress"
                     >
@@ -138,6 +138,7 @@ onMounted(() => {});
                         display: inline-block;
                         background-color: darkgoldenrod;
                         height: 400px;
+                        margin-left: 6rem;
                     "
                 ></div>
             </div>
@@ -149,5 +150,9 @@ onMounted(() => {});
 .inline-block {
     display: inline-block;
     width: unset;
+}
+
+.container-width {
+    width: 1058;
 }
 </style>


### PR DESCRIPTION
This PR fixes the 'Next' button sometimes having an incorrect label. It also ensures that both buttons work identically. Lastly, it fixes the CSS for the 'Next' button on Step3_SpatialLocation, where it would move over to the right.

NOTE: automatic validation still happens on Step2_SiteAddress because it's using the old Zod validation logic and no PrimeVue Form.