### PR TITLE
Fix 'Add' button being inccorectly enabled/disabled on some steps

### DIFF
--- a/bcrhp/src/bcrhp/pages/steps/Step4_SiteNames.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step4_SiteNames.vue
@@ -31,7 +31,8 @@ const isValid = () => {
 const saveOtherName = function () {
     console.log('saveOtherName');
     heritageSiteRef.value.otherNames.push(otherName.value);
-    otherName.value = '';
+
+    siteNamesForm.value?.reset();
 };
 
 const addOtherNameDisabled = computed(

--- a/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step5_RecognitionDetails.vue
@@ -22,7 +22,7 @@ import {
 import { DATE_FORMAT } from '@/bcrhp/constants.ts';
 
 const recognitionDetailsForm: Ref<FormInstance | null> = useTemplateRef(
-    'recognitionDetailsRef',
+    'recognitionDetailsForm',
 ) as Ref<FormInstance | null>;
 
 const heritageSite: typeof HeritageSite = inject(
@@ -78,9 +78,7 @@ const saveRecognitionDetails = function () {
         referenceNumber: currentRecognitionDetails.value.referenceNumber,
     });
 
-    currentRecognitionDetails.value.designationDate = null;
-    currentRecognitionDetails.value.legislativeAct = '';
-    currentRecognitionDetails.value.referenceNumber = '';
+    recognitionDetailsForm?.value?.reset();
 };
 
 const deleteRecognitionDetailsCallback = function (index: number) {
@@ -102,9 +100,9 @@ onMounted(() => {
 </script>
 <template>
     <Form
-        ref="recognitionDetailsRef"
+        ref="recognitionDetailsForm"
         v-slot="$form"
-        name="recognitionDetailsRef"
+        name="recognitionDetailsForm"
         :validateOnBlur="true"
     >
         <FieldSet id="recognitionDetailsFieldset">

--- a/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step8_SiteClassification.vue
@@ -28,8 +28,14 @@ const heritageSite: typeof HeritageSite = inject(
 ) as typeof HeritageSite;
 const heritageSiteRef: Ref<typeof HeritageSite> = ref(heritageSite);
 
-const siteClassificationForm: Ref<FormInstance | null> = useTemplateRef(
-    'siteClassificationForm',
+const heritageClassForm: Ref<FormInstance | null> = useTemplateRef(
+    'heritageClassForm',
+) as Ref<FormInstance | null>;
+const heritageFunctionForm: Ref<FormInstance | null> = useTemplateRef(
+    'heritageFunctionForm',
+) as Ref<FormInstance | null>;
+const heritageThemeForm: Ref<FormInstance | null> = useTemplateRef(
+    'heritageThemeForm',
 ) as Ref<FormInstance | null>;
 const currentHeritageClass: typeof HeritageClass = ref(
     getHeritageClassSchema(),
@@ -61,32 +67,38 @@ const zodHeritageThemeResolver = zodResolver(
     HeritageThemeSchema.shape.heritageTheme,
 );
 
-const isValid = () => {
-    return siteClassificationForm.value?.valid;
+const isValidHeritageClass = () => {
+    return heritageClassForm.value?.valid;
+};
+const isValidHeritageFunction = () => {
+    return heritageFunctionForm.value?.valid;
+};
+const isValidHeritageTheme = () => {
+    return heritageThemeForm.value?.valid;
 };
 
 const addOtherHeritageClassDisabled = computed(
     () =>
-        siteClassificationForm.value?.states?.contributingResources?.pristine ||
-        siteClassificationForm.value?.states?.heritageCategory?.pristine ||
-        siteClassificationForm.value?.states?.ownership?.pristine ||
-        siteClassificationForm.value?.states?.contributingResources?.invalid ||
-        siteClassificationForm.value?.states?.heritageCategory?.invalid ||
-        siteClassificationForm.value?.states?.ownership?.invalid ||
+        heritageClassForm.value?.states?.contributingResources?.pristine ||
+        heritageClassForm.value?.states?.heritageCategory?.pristine ||
+        heritageClassForm.value?.states?.ownership?.pristine ||
+        heritageClassForm.value?.states?.contributingResources?.invalid ||
+        heritageClassForm.value?.states?.heritageCategory?.invalid ||
+        heritageClassForm.value?.states?.ownership?.invalid ||
         heritageSiteRef.value.siteClassification?.heritageClasses?.length > 4,
 );
 const addOtherHeritageFunctionDisabled = computed(
     () =>
-        siteClassificationForm.value?.states?.functionCategory?.pristine ||
-        siteClassificationForm.value?.states?.functionCategoryType?.pristine ||
-        siteClassificationForm.value?.states?.heritageCategory?.invalid ||
-        siteClassificationForm.value?.states?.functionCategoryType?.invalid ||
+        heritageFunctionForm.value?.states?.functionCategory?.pristine ||
+        heritageFunctionForm.value?.states?.functionCategoryType?.pristine ||
+        heritageFunctionForm.value?.states?.heritageCategory?.invalid ||
+        heritageFunctionForm.value?.states?.functionCategoryType?.invalid ||
         heritageSiteRef.value.siteClassification?.heritageFunctions?.length > 4,
 );
 const addOtherHeritageThemeDisabled = computed(
     () =>
-        siteClassificationForm.value?.states?.heritageTheme?.pristine ||
-        siteClassificationForm.value?.states?.heritageTheme?.invalid ||
+        heritageThemeForm.value?.states?.heritageTheme?.pristine ||
+        heritageThemeForm.value?.states?.heritageTheme?.invalid ||
         heritageSiteRef.value.siteClassification?.heritageThemes?.length > 4,
 );
 
@@ -98,9 +110,7 @@ const saveHeritageClass = function () {
         ownership: currentHeritageClass.value.ownership,
     });
 
-    currentHeritageClass.value.contributingResources = 0;
-    currentHeritageClass.value.heritageCategory = '';
-    currentHeritageClass.value.ownership = '';
+    heritageClassForm.value?.reset();
 };
 
 const saveHeritageFunction = function () {
@@ -111,8 +121,7 @@ const saveHeritageFunction = function () {
             currentHeritageFunction.value.functionCategoryType,
     });
 
-    currentHeritageFunction.value.functionCategory = '';
-    currentHeritageFunction.value.functionCategoryType = '';
+    heritageFunctionForm.value?.reset();
 };
 
 const saveHeritageTheme = function () {
@@ -121,7 +130,7 @@ const saveHeritageTheme = function () {
         currentHeritageTheme.value.heritageTheme,
     );
 
-    currentHeritageTheme.value.heritageTheme = '';
+    heritageThemeForm.value?.reset();
 };
 
 const deleteHeritageClassCallback = function (index: number) {
@@ -138,7 +147,11 @@ const deleteHeritageThemeCallback = function (index: number) {
 
 // This needs to be removed - added because ESLint was complaining. Need to figure out
 // configuration so API methods are not
-defineExpose({ isValid });
+defineExpose({
+    isValidHeritageClass,
+    isValidHeritageFunction,
+    isValidHeritageTheme,
+});
 
 onMounted(() => {
     heritageSiteRef.value.siteClassification.heritageClasses = heritageClasses;
@@ -149,9 +162,9 @@ onMounted(() => {
 </script>
 <template>
     <Form
-        ref="siteClassificationForm"
+        ref="heritageClassForm"
         v-slot="$form"
-        name="siteClassificationForm"
+        name="heritageClassForm"
         :validateOnBlur="true"
     >
         <FieldSet
@@ -240,6 +253,13 @@ onMounted(() => {
                 </div>
             </MultiValuePlaceholder>
         </FieldSet>
+    </Form>
+    <Form
+        ref="heritageFunctionForm"
+        v-slot="$form"
+        name="heritageFunctionForm"
+        :validateOnBlur="true"
+    >
         <Fieldset
             id="heritageFunctionFieldset"
             class="p-fieldset p-component mt-2"
@@ -247,7 +267,7 @@ onMounted(() => {
         >
             <LabelledInput
                 label="Function Category"
-                input-name="heritageTheme"
+                input-name="functionCategory"
                 :error-message="$form.functionCategory?.error?.message"
                 :required="true"
             >
@@ -282,15 +302,15 @@ onMounted(() => {
                         </FormField>
                     </div>
                 </div>
-                <Button
-                    id="saveFunctionCategory"
-                    label="Add"
-                    class="inline-block"
-                    :disabled="addOtherHeritageFunctionDisabled"
-                    :aria-disabled="addOtherHeritageFunctionDisabled"
-                    @click="saveHeritageFunction"
-                ></Button>
             </LabelledInput>
+            <Button
+                id="saveFunctionCategory"
+                label="Add"
+                class="inline-block"
+                :disabled="addOtherHeritageFunctionDisabled"
+                :aria-disabled="addOtherHeritageFunctionDisabled"
+                @click="saveHeritageFunction"
+            ></Button>
             <MultiValuePlaceholder
                 v-slot="slotProps"
                 :showDeleteButton="true"
@@ -308,6 +328,13 @@ onMounted(() => {
                 </div>
             </MultiValuePlaceholder>
         </Fieldset>
+    </Form>
+    <Form
+        ref="heritageThemeForm"
+        v-slot="$form"
+        name="heritageThemeForm"
+        :validateOnBlur="true"
+    >
         <Fieldset
             id="heritageThemeFieldset"
             class="p-fieldset p-component mt-2"

--- a/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/steps/Step9_SiteDetails.vue
@@ -35,8 +35,14 @@ const currentURL = ref(getURLsSchema());
 const architectsOrBuilders = ref([] as Array<string>);
 const urls = ref([] as Array<string>);
 
-const siteDetailsForm: Ref<FormInstance | null> = useTemplateRef(
-    'siteDetailsForm',
+const chronologyForm: Ref<FormInstance | null> = useTemplateRef(
+    'chronologyForm',
+) as Ref<FormInstance | null>;
+const architectOrBuilderForm: Ref<FormInstance | null> = useTemplateRef(
+    'architectOrBuilderForm',
+) as Ref<FormInstance | null>;
+const relatedURLsForm: Ref<FormInstance | null> = useTemplateRef(
+    'relatedURLsForm',
 ) as Ref<FormInstance | null>;
 const zodEventTypeResolver = zodResolver(ChronologySchema.shape.eventType);
 const zodStartYearResolver = zodResolver(ChronologySchema.shape.startYear);
@@ -58,40 +64,44 @@ const zodURLTypeResolver = zodResolver(URLsSchema.shape.urlType);
 const zodLinkTextResolver = zodResolver(URLsSchema.shape.linkText);
 const zodURLResolver = zodResolver(URLsSchema.shape.url);
 
-const isValid = () => {
-    return siteDetailsForm.value?.valid;
+const isValidChronology = () => {
+    return chronologyForm.value?.valid;
+};
+const isValidArchitectOrBuilder = () => {
+    return architectOrBuilderForm.value?.valid;
+};
+const isValidRelatedURLs = () => {
+    return relatedURLsForm.value?.valid;
 };
 
 const addChronologyDisabled = computed(
     () =>
-        siteDetailsForm.value?.states?.eventType?.pristine ||
-        siteDetailsForm.value?.states?.startYear?.pristine ||
-        siteDetailsForm.value?.states?.endYear?.pristine ||
-        siteDetailsForm.value?.states?.chronologyNotes?.pristine ||
-        siteDetailsForm.value?.states?.eventType?.invalid ||
-        siteDetailsForm.value?.states?.startYear?.invalid ||
-        siteDetailsForm.value?.states?.endYear?.invalid ||
-        siteDetailsForm.value?.states?.chronologyNotes?.invalid ||
+        chronologyForm.value?.states?.eventType?.pristine ||
+        chronologyForm.value?.states?.startYear?.pristine ||
+        chronologyForm.value?.states?.endYear?.pristine ||
+        chronologyForm.value?.states?.eventType?.invalid ||
+        chronologyForm.value?.states?.startYear?.invalid ||
+        chronologyForm.value?.states?.endYear?.invalid ||
         heritageSiteRef.value.siteDetails?.chronologies?.length > 4,
 );
 const addArchitectOrBuilderDisabled = computed(
     () =>
-        siteDetailsForm.value?.states?.architectOrBuilderName?.pristine ||
-        siteDetailsForm.value?.states?.architectOrBuilderNotes?.pristine ||
-        siteDetailsForm.value?.states?.architectOrBuilderType?.pristine ||
-        siteDetailsForm.value?.states?.architectOrBuilderName?.invalid ||
-        siteDetailsForm.value?.states?.architectOrBuilderNotes?.invalid ||
-        siteDetailsForm.value?.states?.architectOrBuilderType?.invalid ||
+        architectOrBuilderForm.value?.states?.architectOrBuilderName
+            ?.pristine ||
+        architectOrBuilderForm.value?.states?.architectOrBuilderType
+            ?.pristine ||
+        architectOrBuilderForm.value?.states?.architectOrBuilderName?.invalid ||
+        architectOrBuilderForm.value?.states?.architectOrBuilderType?.invalid ||
         heritageSiteRef.value.siteDetails?.architectsOrBuilders?.length > 4,
 );
 const addURLDisabled = computed(
     () =>
-        siteDetailsForm.value?.states?.urlType?.pristine ||
-        siteDetailsForm.value?.states?.linkText?.pristine ||
-        siteDetailsForm.value?.states?.url?.pristine ||
-        siteDetailsForm.value?.states?.urlType?.invalid ||
-        siteDetailsForm.value?.states?.linkText?.invalid ||
-        siteDetailsForm.value?.states?.url?.invalid ||
+        relatedURLsForm.value?.states?.urlType?.pristine ||
+        relatedURLsForm.value?.states?.linkText?.pristine ||
+        relatedURLsForm.value?.states?.url?.pristine ||
+        relatedURLsForm.value?.states?.urlType?.invalid ||
+        relatedURLsForm.value?.states?.linkText?.invalid ||
+        relatedURLsForm.value?.states?.url?.invalid ||
         heritageSiteRef.value.siteDetails?.urls?.length > 4,
 );
 
@@ -112,11 +122,7 @@ const saveChronology = function () {
         chronologyNotes: currentChronology.value.chronologyNotes,
     });
 
-    currentChronology.value.eventType = '';
-    currentChronology.value.startYear = null;
-    currentChronology.value.endYear = null;
-    currentChronology.value.circa = false;
-    currentChronology.value.chronologyNotes = '';
+    chronologyForm.value?.reset();
 };
 
 const saveArchitectOrBuilder = function () {
@@ -130,9 +136,7 @@ const saveArchitectOrBuilder = function () {
             currentArchitectOrBuilder.value.architectOrBuilderNotes,
     });
 
-    currentArchitectOrBuilder.value.architectOrBuilderName = '';
-    currentArchitectOrBuilder.value.architectOrBuilderType = '';
-    currentArchitectOrBuilder.value.architectOrBuilderNotes = '';
+    architectOrBuilderForm.value?.reset();
 };
 const saveURL = function () {
     console.log('saveURL');
@@ -142,9 +146,7 @@ const saveURL = function () {
         url: currentURL.value.url,
     });
 
-    currentURL.value.urlType = '';
-    currentURL.value.linkText = '';
-    currentURL.value.url = '';
+    relatedURLsForm.value?.reset();
 };
 
 const deleteChronologyCallback = function (index: number) {
@@ -161,7 +163,11 @@ const deleteURLCallback = function (index: number) {
 
 // This needs to be removed - added because ESLint was complaining. Need to figure out
 // configuration so API methods are not
-defineExpose({ isValid });
+defineExpose({
+    isValidChronology,
+    isValidArchitectOrBuilder,
+    isValidRelatedURLs,
+});
 
 onMounted(() => {
     heritageSiteRef.value.siteDetails.chronologies = chronologies;
@@ -172,9 +178,9 @@ onMounted(() => {
 </script>
 <template>
     <Form
-        ref="siteDetailsForm"
+        ref="chronologyForm"
         v-slot="$form"
-        name="siteDetailsForm"
+        name="chronologyForm"
         :validateOnBlur="true"
     >
         <FieldSet
@@ -295,6 +301,13 @@ onMounted(() => {
                 </div>
             </MultiValuePlaceholder>
         </FieldSet>
+    </Form>
+    <Form
+        ref="architectOrBuilderForm"
+        v-slot="$form"
+        name="architectOrBuilderForm"
+        :validateOnBlur="true"
+    >
         <Fieldset
             id="architectsBuildersFieldset"
             class="p-fieldset p-component mt-2"
@@ -408,6 +421,13 @@ onMounted(() => {
                 </div>
             </MultiValuePlaceholder>
         </Fieldset>
+    </Form>
+    <Form
+        ref="relatedURLsForm"
+        v-slot="$form"
+        name="relatedURLsForm"
+        :validateOnBlur="true"
+    >
         <Fieldset
             id="relatedURLsFieldset"
             class="p-fieldset p-component mt-2"

--- a/bcrhp/src/bcrhp/schema/SiteClassificationSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteClassificationSchema.ts
@@ -47,7 +47,12 @@ const HeritageFunctionSchema = z.object({
         })
         .min(1, { message: 'Function Category is required.' })
         .max(250),
-    functionCategoryType: z.string().max(12),
+    functionCategoryType: z
+        .string({
+            invalid_type_error: 'Heritage Category Type is required.',
+        })
+        .min(1, { message: 'Heritage Category Type is required.' })
+        .max(250),
 });
 const HeritageThemeSchema = z.object({
     heritageTheme: z

--- a/bcrhp/src/bcrhp/schema/SiteDetailsSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteDetailsSchema.ts
@@ -6,11 +6,16 @@ const SiteDetailsSchema = z.object({
     urls: z.array(z.string()).max(5),
 });
 const ChronologySchema = z.object({
-    eventType: z.string().max(20),
+    eventType: z
+        .string({
+            invalid_type_error: 'Event Type is required.',
+        })
+        .min(1, { message: 'Event Type is required.' })
+        .max(250),
     startYear: z.date(),
     endYear: z.date(),
-    circa: z.string().max(20),
-    chronologyNotes: z.string().max(1000),
+    circa: z.string().max(20).nullable(),
+    chronologyNotes: z.string().max(1000).nullable(),
 });
 
 const ArchitectBuilderSchema = z.object({
@@ -20,10 +25,10 @@ const ArchitectBuilderSchema = z.object({
         })
         .min(1, { message: 'Architect or Builder Name is required.' })
         .max(250),
-    architectOrBuilderNotes: z.string().max(4000),
+    architectOrBuilderNotes: z.string().max(4000).nullable(),
     architectOrBuilderType: z
         .string({
-            invalid_type_error: 'Architect or Builder Name is required.',
+            invalid_type_error: 'Architect or Builder Type is required.',
         })
         .min(1, { message: 'Architect or Builder Type is required.' })
         .max(250),


### PR DESCRIPTION
This PR fixes a bug on Step4, Step5, Step8 and Step9 where the 'Add' button would remain enabled after being pressed, even though the values were added to the array and then cleared. It also fixes a bug on Step8, where the 'Add' button would remain disabled even though the Heritage Function values were entered.