### PR TITLE
1292 - Fix quill dependency issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "ckeditor5": "44.2.0",
                 "js-cookie": "^2.1.1",
                 "primevue": "^4.2.5",
-                "quill": "^1.3.7",
+                "quill": "^2.0.3",
                 "rollup": "^4.34.8",
                 "tailwindcss": "^4.0.13",
                 "tailwindcss-primeui": "^0.5.1",
@@ -15081,12 +15081,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "license": "MIT"
-        },
         "node_modules/extend-shallow": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -15177,7 +15171,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
             "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/fast-glob": {
@@ -21111,9 +21104,9 @@
             }
         },
         "node_modules/parchment": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
-            "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+            "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
             "license": "BSD-3-Clause"
         },
         "node_modules/parent-module": {
@@ -22658,43 +22651,38 @@
             "license": "ISC"
         },
         "node_modules/quill": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
-            "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
+            "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "clone": "^2.1.1",
-                "deep-equal": "^1.0.1",
-                "eventemitter3": "^2.0.3",
-                "extend": "^3.0.2",
-                "parchment": "^1.1.4",
-                "quill-delta": "^3.6.2"
+                "eventemitter3": "^5.0.1",
+                "lodash-es": "^4.17.21",
+                "parchment": "^3.0.0",
+                "quill-delta": "^5.1.0"
+            },
+            "engines": {
+                "npm": ">=8.2.3"
             }
         },
         "node_modules/quill-delta": {
-            "version": "3.6.3",
-            "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
-            "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+            "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
             "license": "MIT",
             "dependencies": {
-                "deep-equal": "^1.0.1",
-                "extend": "^3.0.2",
-                "fast-diff": "1.1.2"
+                "fast-diff": "^1.3.0",
+                "lodash.clonedeep": "^4.5.0",
+                "lodash.isequal": "^4.5.0"
             },
             "engines": {
-                "node": ">=0.10"
+                "node": ">= 12.0.0"
             }
         },
-        "node_modules/quill-delta/node_modules/fast-diff": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-            "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-            "license": "Apache-2.0"
-        },
         "node_modules/quill/node_modules/eventemitter3": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-            "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
             "license": "MIT"
         },
         "node_modules/randombytes": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "ckeditor5": "44.2.0",
         "js-cookie": "^2.1.1",
         "primevue": "^4.2.5",
-        "quill": "^1.3.7",
+        "quill": "^2.0.3",
         "rollup": "^4.34.8",
         "tailwindcss": "^4.0.13",
         "tailwindcss-primeui": "^0.5.1",


### PR DESCRIPTION
Update Quill dependency from 1.3.7 -> 2.0.3

closes bcgov/BCHeritage#1292