### PR TITLE
1293 Fix Step6_SOS rich text fields not being validated as mandatory

### DIFF
--- a/bcrhp/src/bcrhp/schema/SiteImagesSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteImagesSchema.ts
@@ -1,4 +1,13 @@
+import sanitizeHtml from 'sanitize-html';
 import { z } from 'zod';
+
+function normalizeEditorContent(value: string | null): string {
+    if (!value) return '';
+
+    return sanitizeHtml(value, { allowedTags: [], allowedAttributes: {} })
+        .replace(/&nbsp;/g, ' ')
+        .trim();
+}
 
 const SiteImagesSchema = z.object({
     imageType: z
@@ -12,9 +21,15 @@ const SiteImagesSchema = z.object({
     imageFeatures: z.string().max(250).nullable(),
     imageDate: z.date(),
     imageDescription: z
-        .string({ invalid_type_error: 'Image Type is required.' })
-        .min(1, { message: 'Image Description is required.' })
-        .max(250),
+        .string()
+        .transform(normalizeEditorContent)
+        .refine((value: string) => value !== '', {
+            message: 'Image Description is required.',
+        })
+        .refine((value: string) => value.length <= 250, {
+            message: 'Image Description must be 250 characters or less.',
+        })
+        .nullable(),
     photographer: z.string().max(250).nullable(),
     copyright: z.string().max(250).nullable(),
 });

--- a/bcrhp/src/bcrhp/schema/StatementOfSignificanceSchema.ts
+++ b/bcrhp/src/bcrhp/schema/StatementOfSignificanceSchema.ts
@@ -1,30 +1,49 @@
 import { z } from 'zod';
 
+function normalizeEditorContent(value: string | null): string {
+    if (!value) return '';
+
+    return value
+        .replace(/<[^>]*>/g, '')
+        .replace(/&nbsp;/g, ' ')
+        .trim();
+}
+
 const StatementOfSignificanceSchema = z.object({
-    description: z
-        .string({
-            invalid_type_error: 'Description is required.',
+    description: z.string()
+        .transform(normalizeEditorContent)
+        .refine((value: string) => value !== '', {
+            message: 'Description is required.',
         })
-        .min(1, { message: 'Description is required.' })
-        .max(4000),
-    heritageValue: z
-        .string({
-            invalid_type_error: 'Heritage Value is required.',
+        .refine((value: string) => value.length <= 500, {
+            message: 'Description must be 500 characters or less.',
         })
-        .min(1, { message: 'Heritage Value is required.' })
-        .max(4000),
+        .nullable(),
+    heritageValue: z.string()
+        .transform(normalizeEditorContent)
+        .refine((value: string) => value !== '', {
+            message: 'Heritage Value is required.',
+        })
+        .refine((value: string) => value.length <= 500, {
+            message: 'Heritage Value must be 500 characters or less.',
+        })
+        .nullable(),
     definingElements: z
-        .string({
-            invalid_type_error: 'Defining Elements is required.',
+        .string()
+        .transform(normalizeEditorContent)
+        .refine((value: string) => value !== '', {
+            message: 'Defining Elements are required.',
         })
-        .min(1, { message: 'Defining Elements is required.' })
-        .max(4000),
+        .refine((value: string) => value.length <= 500, {
+            message: 'Defining Elements must be 500 characters or less.',
+        })
+        .nullable(),
     documentLocation: z
         .string({
             invalid_type_error: 'Document Location is required.',
         })
         .min(1, { message: 'Document Location is required.' })
-        .max(250),
+        .max(250).nullable(),
 });
 
 const requiredStatementOfSignificanceSchema =

--- a/bcrhp/src/bcrhp/schema/StatementOfSignificanceSchema.ts
+++ b/bcrhp/src/bcrhp/schema/StatementOfSignificanceSchema.ts
@@ -1,16 +1,17 @@
+import sanitizeHtml from 'sanitize-html';
 import { z } from 'zod';
 
 function normalizeEditorContent(value: string | null): string {
     if (!value) return '';
 
-    return value
-        .replace(/<[^>]*>/g, '')
+    return sanitizeHtml(value, { allowedTags: [], allowedAttributes: {} })
         .replace(/&nbsp;/g, ' ')
         .trim();
 }
 
 const StatementOfSignificanceSchema = z.object({
-    description: z.string()
+    description: z
+        .string()
         .transform(normalizeEditorContent)
         .refine((value: string) => value !== '', {
             message: 'Description is required.',
@@ -19,7 +20,8 @@ const StatementOfSignificanceSchema = z.object({
             message: 'Description must be 500 characters or less.',
         })
         .nullable(),
-    heritageValue: z.string()
+    heritageValue: z
+        .string()
         .transform(normalizeEditorContent)
         .refine((value: string) => value !== '', {
             message: 'Heritage Value is required.',
@@ -43,7 +45,8 @@ const StatementOfSignificanceSchema = z.object({
             invalid_type_error: 'Document Location is required.',
         })
         .min(1, { message: 'Document Location is required.' })
-        .max(250).nullable(),
+        .max(250)
+        .nullable(),
 });
 
 const requiredStatementOfSignificanceSchema =

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "primevue": "^4.2.5",
                 "quill": "^2.0.3",
                 "rollup": "^4.34.8",
+                "sanitize-html": "^2.17.0",
                 "tailwindcss": "^4.0.13",
                 "tailwindcss-primeui": "^0.5.1",
                 "vite": "^6.2.1",
@@ -35,6 +36,7 @@
             "devDependencies": {
                 "@eslint/js": "^9.20.0",
                 "@primevue/auto-import-resolver": "^4.3.1",
+                "@types/sanitize-html": "^2.16.0",
                 "@typescript-eslint/parser": "^8.24.1",
                 "@vue/eslint-config-prettier": "^10.2.0",
                 "@vue/eslint-config-typescript": "^14.4.0",
@@ -7648,6 +7650,82 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/sanitize-html": {
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.0.tgz",
+            "integrity": "sha512-l6rX1MUXje5ztPT0cAFtUayXF06DqPhRyfVXareEN5gGCFaP/iwsxIyKODr9XDhfxPpN6vXUFNfo5kZMXCxBtw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "htmlparser2": "^8.0.0"
+            }
+        },
+        "node_modules/@types/sanitize-html/node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/@types/sanitize-html/node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/@types/sanitize-html/node_modules/domutils": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/@types/sanitize-html/node_modules/htmlparser2": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+            "dev": true,
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.0.1",
+                "entities": "^4.4.0"
+            }
+        },
         "node_modules/@types/send": {
             "version": "0.17.5",
             "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
@@ -13325,7 +13403,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
             "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -14019,7 +14096,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -17567,7 +17643,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
             "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -20718,6 +20793,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/parse-srcset": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+            "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+            "license": "MIT"
+        },
         "node_modules/parse5": {
             "version": "7.3.0",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -23161,6 +23242,82 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "license": "MIT"
+        },
+        "node_modules/sanitize-html": {
+            "version": "2.17.0",
+            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.0.tgz",
+            "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
+            "license": "MIT",
+            "dependencies": {
+                "deepmerge": "^4.2.2",
+                "escape-string-regexp": "^4.0.0",
+                "htmlparser2": "^8.0.0",
+                "is-plain-object": "^5.0.0",
+                "parse-srcset": "^1.0.2",
+                "postcss": "^8.3.11"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/domutils": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/htmlparser2": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.0.1",
+                "entities": "^4.4.0"
+            }
         },
         "node_modules/sass": {
             "version": "1.78.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3674,9 +3674,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
-            "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+            "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3684,9 +3684,9 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.15.1",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-            "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+            "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3758,9 +3758,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.32.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
-            "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
+            "version": "9.33.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
+            "integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3781,13 +3781,13 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
-            "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+            "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.15.1",
+                "@eslint/core": "^0.15.2",
                 "levn": "^0.4.1"
             },
             "engines": {
@@ -4075,6 +4075,34 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@inquirer/external-editor": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.0.tgz",
+            "integrity": "sha512-5v3YXc5ZMfL6OJqXPrX9csb4l7NlQA2doO1yynUjpUChT9hg4JcuBVP0RbsEJ/3SL/sxWEyFjT2W69ZhtoBWqg==",
+            "license": "MIT",
+            "dependencies": {
+                "chardet": "^2.1.0",
+                "iconv-lite": "^0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -4328,17 +4356,19 @@
             }
         },
         "node_modules/@jsonjoy.com/json-pack": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.8.0.tgz",
-            "integrity": "sha512-paJGjyBTRzfgkqhIyer992g21aSKuu9h//zGS7aqm795roD6VYFf6iU9NYua1Bndmh/NRPkjtm9+hEPkK0yZSw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.10.0.tgz",
+            "integrity": "sha512-PMOU9Sh0baiLZEDewwR/YAHJBV2D8pPIzcFQSU7HQl/k/HNCDyVfO1OvkyDwBGp4dPtvZc7Hl9FFYWwTP1CbZw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/base64": "^1.1.1",
+                "@jsonjoy.com/base64": "^1.1.2",
+                "@jsonjoy.com/buffers": "^1.0.0",
+                "@jsonjoy.com/codegen": "^1.0.0",
                 "@jsonjoy.com/json-pointer": "^1.0.1",
-                "@jsonjoy.com/util": "^1.1.2",
+                "@jsonjoy.com/util": "^1.9.0",
                 "hyperdyperid": "^1.2.0",
-                "thingies": "^1.20.0"
+                "thingies": "^2.5.0"
             },
             "engines": {
                 "node": ">=10.0"
@@ -7453,9 +7483,9 @@
             }
         },
         "node_modules/@types/inquirer": {
-            "version": "8.2.11",
-            "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.2.11.tgz",
-            "integrity": "sha512-15UboTvxb9SOaPG7CcXZ9dkv8lNqfiAwuh/5WxJDLjmElBt9tbx1/FDsEnJddUBKvN4mlPKvr8FyO1rAmBanzg==",
+            "version": "8.2.12",
+            "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.2.12.tgz",
+            "integrity": "sha512-YxURZF2ZsSjU5TAe06tW0M3sL4UI9AMPA6dd8I72uOtppzNafcY38xkYgCZ/vsVOAyNdzHmvtTpLWilOrbP0dQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/through": "*",
@@ -7592,9 +7622,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.2.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
-            "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
+            "version": "24.2.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+            "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.10.0"
@@ -7658,72 +7688,6 @@
             "license": "MIT",
             "dependencies": {
                 "htmlparser2": "^8.0.0"
-            }
-        },
-        "node_modules/@types/sanitize-html/node_modules/dom-serializer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
-                "entities": "^4.2.0"
-            },
-            "funding": {
-                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
-        },
-        "node_modules/@types/sanitize-html/node_modules/domhandler": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "domelementtype": "^2.3.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "node_modules/@types/sanitize-html/node_modules/domutils": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "dom-serializer": "^2.0.0",
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "node_modules/@types/sanitize-html/node_modules/htmlparser2": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-            "dev": true,
-            "funding": [
-                "https://github.com/fb55/htmlparser2?sponsor=1",
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.3",
-                "domutils": "^3.0.1",
-                "entities": "^4.4.0"
             }
         },
         "node_modules/@types/send": {
@@ -7816,17 +7780,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.0.tgz",
-            "integrity": "sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
+            "integrity": "sha512-yYegZ5n3Yr6eOcqgj2nJH8cH/ZZgF+l0YIdKILSDjYFRjgYQMgv/lRjV5Z7Up04b9VYUondt8EPMqg7kTWgJ2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.39.0",
-                "@typescript-eslint/type-utils": "8.39.0",
-                "@typescript-eslint/utils": "8.39.0",
-                "@typescript-eslint/visitor-keys": "8.39.0",
+                "@typescript-eslint/scope-manager": "8.39.1",
+                "@typescript-eslint/type-utils": "8.39.1",
+                "@typescript-eslint/utils": "8.39.1",
+                "@typescript-eslint/visitor-keys": "8.39.1",
                 "graphemer": "^1.4.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
@@ -7840,7 +7804,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.39.0",
+                "@typescript-eslint/parser": "^8.39.1",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
@@ -7856,16 +7820,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.0.tgz",
-            "integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.1.tgz",
+            "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.39.0",
-                "@typescript-eslint/types": "8.39.0",
-                "@typescript-eslint/typescript-estree": "8.39.0",
-                "@typescript-eslint/visitor-keys": "8.39.0",
+                "@typescript-eslint/scope-manager": "8.39.1",
+                "@typescript-eslint/types": "8.39.1",
+                "@typescript-eslint/typescript-estree": "8.39.1",
+                "@typescript-eslint/visitor-keys": "8.39.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -7881,14 +7845,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.0.tgz",
-            "integrity": "sha512-CTzJqaSq30V/Z2Og9jogzZt8lJRR5TKlAdXmWgdu4hgcC9Kww5flQ+xFvMxIBWVNdxJO7OifgdOK4PokMIWPew==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.1.tgz",
+            "integrity": "sha512-8fZxek3ONTwBu9ptw5nCKqZOSkXshZB7uAxuFF0J/wTMkKydjXCzqqga7MlFMpHi9DoG4BadhmTkITBcg8Aybw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.39.0",
-                "@typescript-eslint/types": "^8.39.0",
+                "@typescript-eslint/tsconfig-utils": "^8.39.1",
+                "@typescript-eslint/types": "^8.39.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -7903,14 +7867,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.0.tgz",
-            "integrity": "sha512-8QOzff9UKxOh6npZQ/4FQu4mjdOCGSdO3p44ww0hk8Vu+IGbg0tB/H1LcTARRDzGCC8pDGbh2rissBuuoPgH8A==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.1.tgz",
+            "integrity": "sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.39.0",
-                "@typescript-eslint/visitor-keys": "8.39.0"
+                "@typescript-eslint/types": "8.39.1",
+                "@typescript-eslint/visitor-keys": "8.39.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7921,9 +7885,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.0.tgz",
-            "integrity": "sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.1.tgz",
+            "integrity": "sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7938,15 +7902,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.0.tgz",
-            "integrity": "sha512-6B3z0c1DXVT2vYA9+z9axjtc09rqKUPRmijD5m9iv8iQpHBRYRMBcgxSiKTZKm6FwWw1/cI4v6em35OsKCiN5Q==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.1.tgz",
+            "integrity": "sha512-gu9/ahyatyAdQbKeHnhT4R+y3YLtqqHyvkfDxaBYk97EcbfChSJXyaJnIL3ygUv7OuZatePHmQvuH5ru0lnVeA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.39.0",
-                "@typescript-eslint/typescript-estree": "8.39.0",
-                "@typescript-eslint/utils": "8.39.0",
+                "@typescript-eslint/types": "8.39.1",
+                "@typescript-eslint/typescript-estree": "8.39.1",
+                "@typescript-eslint/utils": "8.39.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -7963,9 +7927,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.0.tgz",
-            "integrity": "sha512-ArDdaOllnCj3yn/lzKn9s0pBQYmmyme/v1HbGIGB0GB/knFI3fWMHloC+oYTJW46tVbYnGKTMDK4ah1sC2v0Kg==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
+            "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7977,16 +7941,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.0.tgz",
-            "integrity": "sha512-ndWdiflRMvfIgQRpckQQLiB5qAKQ7w++V4LlCHwp62eym1HLB/kw7D9f2e8ytONls/jt89TEasgvb+VwnRprsw==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.1.tgz",
+            "integrity": "sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.39.0",
-                "@typescript-eslint/tsconfig-utils": "8.39.0",
-                "@typescript-eslint/types": "8.39.0",
-                "@typescript-eslint/visitor-keys": "8.39.0",
+                "@typescript-eslint/project-service": "8.39.1",
+                "@typescript-eslint/tsconfig-utils": "8.39.1",
+                "@typescript-eslint/types": "8.39.1",
+                "@typescript-eslint/visitor-keys": "8.39.1",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -8006,16 +7970,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.0.tgz",
-            "integrity": "sha512-4GVSvNA0Vx1Ktwvf4sFE+exxJ3QGUorQG1/A5mRfRNZtkBT2xrA/BCO2H0eALx/PnvCS6/vmYwRdDA41EoffkQ==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.1.tgz",
+            "integrity": "sha512-VF5tZ2XnUSTuiqZFXCZfZs1cgkdd3O/sSYmdo2EpSyDlC86UM/8YytTmKnehOW3TGAlivqTDT6bS87B/GQ/jyg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.39.0",
-                "@typescript-eslint/types": "8.39.0",
-                "@typescript-eslint/typescript-estree": "8.39.0"
+                "@typescript-eslint/scope-manager": "8.39.1",
+                "@typescript-eslint/types": "8.39.1",
+                "@typescript-eslint/typescript-estree": "8.39.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8030,13 +7994,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.0.tgz",
-            "integrity": "sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.1.tgz",
+            "integrity": "sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.39.0",
+                "@typescript-eslint/types": "8.39.1",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -9416,7 +9380,7 @@
         },
         "node_modules/arches-component-lab": {
             "name": "arches_component_lab",
-            "resolved": "git+ssh://git@github.com/archesproject/arches-component-lab.git#1d86e559a8245ba20d5822cf9b08f09ccc30b779",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-component-lab.git#048d82730e333cce21b0de6a1a761762e842faca",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@primevue/forms": "4.3.3",
@@ -9529,7 +9493,7 @@
         },
         "node_modules/arches-component-lab/node_modules/arches": {
             "version": "8.0.3",
-            "resolved": "git+ssh://git@github.com/archesproject/arches.git#f5b9fa6b4811b9b7c095714e7bbe379bcdd1ebe9",
+            "resolved": "git+ssh://git@github.com/archesproject/arches.git#7f4e45ef5dd94f5fe9ec05e6c03fe90090c4950b",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@babel/runtime": "^7.17.2",
@@ -10238,11 +10202,11 @@
         },
         "node_modules/bcgov_arches_common": {
             "name": "bcgov-arches-common",
-            "version": "1.2.4",
-            "resolved": "git+ssh://git@github.com/bcgov/bcgov-arches-common.git#b1bf448932604e739ca45e85354a79dac41f46c5",
+            "version": "1.2.5",
+            "resolved": "git+ssh://git@github.com/bcgov/bcgov-arches-common.git#1b93dbe422a578a2335b24f2ff8e99f3e7923b5d",
             "license": "AGPL-3.0-only",
             "dependencies": {
-                "arches": "bcgov/arches#v7.6.12.1_bcgov",
+                "arches": "github:bcgov/arches#7.6.12+bcgov.1",
                 "primevue": "^4.2.5",
                 "vite": "latest",
                 "vue-router": "^4.4.3"
@@ -10524,9 +10488,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.25.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-            "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+            "version": "4.25.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
+            "integrity": "sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -10543,8 +10507,8 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001726",
-                "electron-to-chromium": "^1.5.173",
+                "caniuse-lite": "^1.0.30001733",
+                "electron-to-chromium": "^1.5.199",
                 "node-releases": "^2.0.19",
                 "update-browserslist-db": "^1.1.3"
             },
@@ -10873,9 +10837,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001731",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-            "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
+            "version": "1.0.30001734",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz",
+            "integrity": "sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -10943,9 +10907,9 @@
             }
         },
         "node_modules/chardet": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+            "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
             "license": "MIT"
         },
         "node_modules/check-error": {
@@ -11307,9 +11271,9 @@
             }
         },
         "node_modules/codemirror": {
-            "version": "5.65.19",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.19.tgz",
-            "integrity": "sha512-+aFkvqhaAVr1gferNMuN8vkTSrWIFvzlMV9I2KBLCWS2WpZ2+UAkZjlMZmEuT+gcXTi6RrGQCkWq1/bDtGqhIA==",
+            "version": "5.65.20",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.20.tgz",
+            "integrity": "sha512-i5dLDDxwkFCbhjvL2pNjShsojoL3XHyDwsGv1jqETUoW+lzpBKKqNTUWgQwVAOa0tUm4BwekT455ujafi8payA==",
             "license": "MIT"
         },
         "node_modules/collection-visit": {
@@ -11973,6 +11937,62 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/css-select/node_modules/dom-serializer": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.0",
+                "entities": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/css-select/node_modules/domhandler": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/css-select/node_modules/domutils": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/css-select/node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/css-selector-parser": {
@@ -13358,28 +13378,17 @@
             }
         },
         "node_modules/dom-serializer": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-            "dev": true,
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "license": "MIT",
             "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.0",
-                "entities": "^2.0.0"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
             },
             "funding": {
                 "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
-        },
-        "node_modules/dom-serializer/node_modules/entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/dom4": {
@@ -13412,13 +13421,12 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-            "dev": true,
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "license": "BSD-2-Clause",
             "dependencies": {
-                "domelementtype": "^2.2.0"
+                "domelementtype": "^2.3.0"
             },
             "engines": {
                 "node": ">= 4"
@@ -13428,15 +13436,14 @@
             }
         },
         "node_modules/domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-            "dev": true,
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
             "license": "BSD-2-Clause",
             "dependencies": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -13766,9 +13773,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.195",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.195.tgz",
-            "integrity": "sha512-URclP0iIaDUzqcAyV1v2PgduJ9N0IdXmWsnPzPfelvBmjmZzEy6xJcjb1cXj+TbYqXgtLrjHEoaSIdTYhw4ezg==",
+            "version": "1.5.200",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz",
+            "integrity": "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==",
             "license": "ISC"
         },
         "node_modules/elliptic": {
@@ -13827,9 +13834,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.2",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
-            "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
+            "version": "5.18.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+            "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -14105,20 +14112,20 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.32.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
-            "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
+            "version": "9.33.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
+            "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
                 "@eslint/config-array": "^0.21.0",
-                "@eslint/config-helpers": "^0.3.0",
-                "@eslint/core": "^0.15.0",
+                "@eslint/config-helpers": "^0.3.1",
+                "@eslint/core": "^0.15.2",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.32.0",
-                "@eslint/plugin-kit": "^0.3.4",
+                "@eslint/js": "9.33.0",
+                "@eslint/plugin-kit": "^0.3.5",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
@@ -14182,9 +14189,9 @@
             }
         },
         "node_modules/eslint-plugin-prettier": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.3.tgz",
-            "integrity": "sha512-NAdMYww51ehKfDyDhv59/eIItUVzU0Io9H2E8nHNGKEeeqlnci+1gCvrHib6EmZdf6GxF+LCV5K7UC65Ezvw7w==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
+            "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14783,6 +14790,12 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/external-editor/node_modules/chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "license": "MIT"
         },
         "node_modules/extglob": {
             "version": "2.0.4",
@@ -15878,9 +15891,9 @@
             }
         },
         "node_modules/gl-matrix": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
-            "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+            "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
             "license": "MIT"
         },
         "node_modules/glob": {
@@ -16612,10 +16625,9 @@
             }
         },
         "node_modules/htmlparser2": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-            "dev": true,
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -16625,17 +16637,16 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.0.0",
-                "domutils": "^2.5.2",
-                "entities": "^2.0.0"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.0.1",
+                "entities": "^4.4.0"
             }
         },
         "node_modules/htmlparser2/node_modules/entities": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
             "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
@@ -17033,16 +17044,16 @@
             }
         },
         "node_modules/inquirer": {
-            "version": "8.2.6",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
-            "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+            "version": "8.2.7",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
+            "integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
             "license": "MIT",
             "dependencies": {
+                "@inquirer/external-editor": "^1.0.0",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.1.1",
                 "cli-cursor": "^3.1.0",
                 "cli-width": "^3.0.0",
-                "external-editor": "^3.0.3",
                 "figures": "^3.0.0",
                 "lodash": "^4.17.21",
                 "mute-stream": "0.0.8",
@@ -18604,9 +18615,9 @@
             "license": "MIT"
         },
         "node_modules/launch-editor": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.0.tgz",
-            "integrity": "sha512-R/PIF14L6e2eHkhvQPu7jDRCr0msfCYCxbYiLgkkAGi0dVPWuM+RrsPu0a5dpuNe0KWGL3jpAkOlv53xGfPheQ==",
+            "version": "2.11.1",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
+            "integrity": "sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==",
             "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.1.1",
@@ -19580,9 +19591,9 @@
             }
         },
         "node_modules/mini-css-extract-plugin": {
-            "version": "2.9.3",
-            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.3.tgz",
-            "integrity": "sha512-tRA0+PsS4kLVijnN1w9jUu5lkxBwUk9E8SbgEB5dBJqchE6pVYdawROG6uQtpmAri7tdCK9i7b1bULeVWqS6Ag==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
+            "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -22786,6 +22797,82 @@
                 "strip-ansi": "^6.0.1"
             }
         },
+        "node_modules/renderkid/node_modules/dom-serializer": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.0",
+                "entities": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/renderkid/node_modules/domhandler": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/renderkid/node_modules/domutils": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/renderkid/node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/renderkid/node_modules/htmlparser2": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+            "dev": true,
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0",
+                "domutils": "^2.5.2",
+                "entities": "^2.0.0"
+            }
+        },
         "node_modules/repeat-element": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
@@ -23255,68 +23342,6 @@
                 "is-plain-object": "^5.0.0",
                 "parse-srcset": "^1.0.2",
                 "postcss": "^8.3.11"
-            }
-        },
-        "node_modules/sanitize-html/node_modules/dom-serializer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-            "license": "MIT",
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
-                "entities": "^4.2.0"
-            },
-            "funding": {
-                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
-        },
-        "node_modules/sanitize-html/node_modules/domhandler": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "domelementtype": "^2.3.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "node_modules/sanitize-html/node_modules/domutils": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "dom-serializer": "^2.0.0",
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "node_modules/sanitize-html/node_modules/htmlparser2": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-            "funding": [
-                "https://github.com/fb55/htmlparser2?sponsor=1",
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.3",
-                "domutils": "^3.0.1",
-                "entities": "^4.4.0"
             }
         },
         "node_modules/sass": {
@@ -24288,9 +24313,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.21",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-            "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+            "version": "3.0.22",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+            "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
             "license": "CC0-1.0"
         },
         "node_modules/spdy": {
@@ -24742,9 +24767,9 @@
             }
         },
         "node_modules/stylelint": {
-            "version": "16.23.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.23.0.tgz",
-            "integrity": "sha512-69T5aS2LUY306ekt1Q1oaSPwz/jaG9HjyMix3UMrai1iEbuOafBe2Dh8xlyczrxFAy89qcKyZWWtc42XLx3Bbw==",
+            "version": "16.23.1",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.23.1.tgz",
+            "integrity": "sha512-dNvDTsKV1U2YtiUDfe9d2gp902veFeo3ecCWdGlmLm2WFrAV0+L5LoOj/qHSBABQwMsZPJwfC4bf39mQm1S5zw==",
             "dev": true,
             "funding": [
                 {
@@ -25509,13 +25534,17 @@
             "license": "MIT"
         },
         "node_modules/thingies": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
-            "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
+            "integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
             "dev": true,
-            "license": "Unlicense",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
             },
             "peerDependencies": {
                 "tslib": "^2"
@@ -26137,16 +26166,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.0.tgz",
-            "integrity": "sha512-lH8FvtdtzcHJCkMOKnN73LIn6SLTpoojgJqDAxPm1jCR14eWSGPX8ul/gggBdPMk/d5+u9V854vTYQ8T5jF/1Q==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.1.tgz",
+            "integrity": "sha512-GDUv6/NDYngUlNvwaHM1RamYftxf782IyEDbdj3SeaIHHv8fNQVRC++fITT7kUJV/5rIA/tkoRSSskt6osEfqg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.39.0",
-                "@typescript-eslint/parser": "8.39.0",
-                "@typescript-eslint/typescript-estree": "8.39.0",
-                "@typescript-eslint/utils": "8.39.0"
+                "@typescript-eslint/eslint-plugin": "8.39.1",
+                "@typescript-eslint/parser": "8.39.1",
+                "@typescript-eslint/typescript-estree": "8.39.1",
+                "@typescript-eslint/utils": "8.39.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -26347,14 +26376,14 @@
             }
         },
         "node_modules/unplugin-utils": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.2.4.tgz",
-            "integrity": "sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==",
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.2.5.tgz",
+            "integrity": "sha512-gwXJnPRewT4rT7sBi/IvxKTjsms7jX7QIDLOClApuZwR49SXbrB1z2NLUZ+vDHyqCj/n58OzRRqaW+B8OZi8vg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "pathe": "^2.0.2",
-                "picomatch": "^4.0.2"
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3"
             },
             "engines": {
                 "node": ">=18.12.0"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "devDependencies": {
         "@eslint/js": "^9.20.0",
         "@primevue/auto-import-resolver": "^4.3.1",
+        "@types/sanitize-html": "^2.16.0",
         "@typescript-eslint/parser": "^8.24.1",
         "@vue/eslint-config-prettier": "^10.2.0",
         "@vue/eslint-config-typescript": "^14.4.0",
@@ -59,6 +60,7 @@
         "primevue": "^4.2.5",
         "quill": "^2.0.3",
         "rollup": "^4.34.8",
+        "sanitize-html": "^2.17.0",
         "tailwindcss": "^4.0.13",
         "tailwindcss-primeui": "^0.5.1",
         "vite": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
         "moment-timezone": "^0.5.45",
         "nomnom": "npm:@gerhobbelt/nomnom",
         "rimraf": "^5.0.7",
-        "underscore": "^1.13.6"
+        "underscore": "^1.13.6",
+        "sanitize-html": {
+            "entities": "2.2.0"
+        }
     },
     "devDependencies": {
         "@eslint/js": "^9.20.0",


### PR DESCRIPTION
This PR fixes a bug on Step6_SOS where the rich text fields (PrimeVue Editor) were not being as mandatory. This was due to the HTML tags being present in the field, for example <p></p>, which made the field appear empty, but would pass Zod validation.

closes bcgov/BCHeritage#1293