### PR TITLE
1293 Fix rich text fields not being validated as mandatory

### DIFF
--- a/bcrhp/src/bcrhp/schema/SiteImagesSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteImagesSchema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import DOMPurify from 'dompurify';
 
 const SiteImagesSchema = z.object({
     imageType: z
@@ -6,15 +7,25 @@ const SiteImagesSchema = z.object({
         .min(1, { message: 'Image Type is required.' })
         .max(250),
     imageView: z
-        .string({ invalid_type_error: 'Image Type is required.' })
+        .string({ invalid_type_error: 'Image View is required.' })
         .min(1, { message: 'Image View is required.' })
         .max(250),
     imageFeatures: z.string().max(250).nullable(),
     imageDate: z.date(),
     imageDescription: z
-        .string({ invalid_type_error: 'Image Type is required.' })
-        .min(1, { message: 'Image Description is required.' })
-        .max(250),
+        .string()
+        .transform((value: string) => {
+            return DOMPurify.sanitize(value, {
+                ALLOWED_TAGS: [],
+            });
+        })
+        .refine((value: string) => value !== '', {
+            message: 'Image Description is required.',
+        })
+        .refine((value: string) => value.length <= 250, {
+            message: 'Image Description must be 250 characters or less.',
+        })
+        .nullable(),
     photographer: z.string().max(250).nullable(),
     copyright: z.string().max(250).nullable(),
 });

--- a/bcrhp/src/bcrhp/schema/StatementOfSignificanceSchema.ts
+++ b/bcrhp/src/bcrhp/schema/StatementOfSignificanceSchema.ts
@@ -1,24 +1,49 @@
 import { z } from 'zod';
+import DOMPurify from 'dompurify';
 
 const StatementOfSignificanceSchema = z.object({
     description: z
-        .string({
-            invalid_type_error: 'Description is required.',
+        .string()
+        .transform((value: string) => {
+            return DOMPurify.sanitize(value, {
+                ALLOWED_TAGS: [],
+            });
         })
-        .min(1, { message: 'Description is required.' })
-        .max(4000),
+        .refine((value: string) => value !== '', {
+            message: 'Description is required.',
+        })
+        .refine((value: string) => value.length <= 4000, {
+            message: 'Description must be 4000 characters or less.',
+        })
+        .nullable(),
     heritageValue: z
-        .string({
-            invalid_type_error: 'Heritage Value is required.',
+        .string()
+        .transform((value: string) => {
+            return DOMPurify.sanitize(value, {
+                ALLOWED_TAGS: [],
+            });
         })
-        .min(1, { message: 'Heritage Value is required.' })
-        .max(4000),
+        .refine((value: string) => value !== '', {
+            message: 'Heritage Value is required.',
+        })
+        .refine((value: string) => value.length <= 4000, {
+            message: 'Heritage Value must be 4000 characters or less.',
+        })
+        .nullable(),
     definingElements: z
-        .string({
-            invalid_type_error: 'Defining Elements is required.',
+        .string()
+        .transform((value: string) => {
+            return DOMPurify.sanitize(value, {
+                ALLOWED_TAGS: [],
+            });
         })
-        .min(1, { message: 'Defining Elements is required.' })
-        .max(4000),
+        .refine((value: string) => value !== '', {
+            message: 'Defining Elements are required.',
+        })
+        .refine((value: string) => value.length <= 4000, {
+            message: 'Defining Elements must be 4000 characters or less.',
+        })
+        .nullable(),
     documentLocation: z
         .string({
             invalid_type_error: 'Document Location is required.',

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "arches-component-lab": "github:archesproject/arches-component-lab#brf/feat/concept_widgets",
                 "bcgov_arches_common": "github:bcgov/bcgov-arches-common#1.2.5",
                 "ckeditor5": "44.2.0",
+                "dompurify": "^3.2.6",
                 "js-cookie": "^2.1.1",
                 "primevue": "^4.2.5",
                 "quill": "^2.0.3",
@@ -7698,6 +7699,13 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@types/turndown": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.5.tgz",
@@ -13348,6 +13356,15 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/dompurify": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+            "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "arches-component-lab": "github:archesproject/arches-component-lab#brf/feat/concept_widgets",
         "bcgov_arches_common": "github:bcgov/bcgov-arches-common#1.2.5",
         "ckeditor5": "44.2.0",
+        "dompurify": "^3.2.6",
         "js-cookie": "^2.1.1",
         "primevue": "^4.2.5",
         "quill": "^2.0.3",


### PR DESCRIPTION
This PR fixes a bug on Step6_SOS and Step7_SiteImages where the rich text fields (PrimeVue Editor) were not being set as mandatory. This was due to the HTML tags being present in the field, for example `<p></p>`, which made the field appear empty, but would pass Zod validation. DOMPurify is used in order to sanitize the text.

closes bcgov/BCHeritage#1293