### PR TITLE
Update Zod schema to match arches querysets schema

### DIFF
--- a/bcrhp/src/bcrhp/pages/NewSite/NewSite.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/NewSite.vue
@@ -26,7 +26,7 @@ import SupportingDocuments from '@/bcrhp/pages/NewSite/steps/Step10_SupportingDo
 import ReviewSubmission from '@/bcrhp/pages/NewSite/steps/Step11_ReviewSubmission.vue';
 
 import { getHeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
-// import { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
+import { HeritageSite } from '@/bcrhp/schema/HeritageSiteSchema.ts';
 
 const activateNextStep = () => {
     myStepper.value.d_value++;

--- a/bcrhp/src/bcrhp/pages/NewSite/steps/Step6_SOS.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/steps/Step6_SOS.vue
@@ -18,16 +18,16 @@ const statementOfSignificanceForm: Ref<FormInstance | null> = useTemplateRef(
     'statementOfSignificanceForm',
 ) as Ref<FormInstance | null>;
 const zodDescriptionResolver = zodResolver(
-    StatementOfSignificanceSchema.shape.description,
+    StatementOfSignificanceSchema.shape['aliased_data'].physical_description,
 );
 const zodHeritageValueResolver = zodResolver(
-    StatementOfSignificanceSchema.shape.heritageValue,
+    StatementOfSignificanceSchema.shape['aliased_data'].heritage_value,
 );
 const zodDefiningElementsResolver = zodResolver(
-    StatementOfSignificanceSchema.shape.definingElements,
+    StatementOfSignificanceSchema.shape['aliased_data'].defining_elements,
 );
 const zodDocumentLocationResolver = zodResolver(
-    StatementOfSignificanceSchema.shape.documentLocation,
+    StatementOfSignificanceSchema.shape['aliased_data'].document_location,
 );
 
 const isValid = () => {
@@ -60,7 +60,8 @@ defineExpose({ isValid });
                             id="description"
                             ref="descriptionField"
                             v-model="
-                                heritageSite.statementOfSignificance.description
+                                heritageSite.bc_statement_of_significance
+                                    .aliased_data.description
                             "
                             placeholder="E.g. The historic place is located at..."
                             theme="snow"
@@ -87,8 +88,8 @@ defineExpose({ isValid });
                             id="heritageValue"
                             ref="heritageValueField"
                             v-model="
-                                heritageSite.statementOfSignificance
-                                    .heritageValue
+                                heritageSite.bc_statement_of_significance
+                                    .aliased_data.heritage_value
                             "
                             placeholder="E.g. The historic place ha aesthetic, cultural and social value for its..."
                             theme="snow"
@@ -115,8 +116,8 @@ defineExpose({ isValid });
                             id="definingElements"
                             ref="definingElementsField"
                             v-model="
-                                heritageSite.statementOfSignificance
-                                    .definingElements
+                                heritageSite.bc_statement_of_significance
+                                    .aliased_data.defining_elements
                             "
                             placeholder="E.g The elements that define the heritage character of the historic place include: ..."
                             theme="snow"
@@ -143,10 +144,10 @@ defineExpose({ isValid });
                             id="documentLocation"
                             ref="documentLocationField"
                             v-model="
-                                heritageSite.statementOfSignificance
-                                    .documentLocation
+                                heritageSite.bc_statement_of_significance
+                                    .aliased_data.document_location
                             "
-                            placeholder="E.g. City of Courtenay, PLanning Department"
+                            placeholder="E.g. City of Courtenay, Planning Department"
                             aria-describedby="document-location-help"
                             aria-required="true"
                             fluid

--- a/bcrhp/src/bcrhp/schema/CivicAddressSchema.ts
+++ b/bcrhp/src/bcrhp/schema/CivicAddressSchema.ts
@@ -1,38 +1,31 @@
 import { z } from 'zod';
+import type { StringValue } from '@/arches_component_lab/datatypes/string/types.ts';
+import { blankStringValue } from '@/bcrhp/utils.ts';
+import { blankConceptValue } from '@/arches_component_lab/datatypes/concept/utils.ts';
 import {
-    LegalDescription,
-    LegalDescriptionSchema,
-} from '@/bcrhp/schema/LegalDescriptionSchema.ts';
+    PostalCodeNodeSchema,
+    ProvinceNodeSchema,
+} from '@bcrhp/schemas/heritage_site/bc_property_address.ts';
+import type { ConceptValue } from '@/arches_component_lab/datatypes/concept/types.ts';
+import {
+    getStringValueSchema,
+    getStringValueRequiredSchema,
+} from '@/bcgov_arches_common/datatypes/string/validation/zod.ts';
 // @todo - Need to make parts of the model required if hasCivicAddress == true
 const CivicAddressSchema = z.object({
-    hasCivicAddress: z.boolean().default(true),
-    overrideAddress: z.boolean().default(false),
-    streetAddress: z
-        .string()
-        .min(1, { message: 'Street Address is required.' })
-        .max(80)
-        .nullable(),
-    city: z
-        .string()
-        .min(1, { message: 'City is required.' })
-        .max(80)
-        .nullable(),
-    postalCode: z
-        .string()
-        .max(7)
-        .refine(
-            (value: string) =>
-                /^[A-Z][0-9][A-Z] [0-9][A-Z][0-9]$/.test(value ?? ''),
-            'Postal Code must be in the form "A0A A0A"',
-        )
-        .nullable(),
-    locality: z.string().max(50).nullable(),
-    locationDescription: z
-        .string()
-        .min(1, { message: 'Location Description is required.' })
-        .max(50)
-        .nullable(),
-    legalDescriptions: z.array(LegalDescriptionSchema),
+    aliased_data: z.object({
+        //hasCivicAddress: z.boolean().default(true),
+        //overrideAddress: z.boolean().default(false),
+        street_address: getStringValueRequiredSchema(80),
+        postal_code: PostalCodeNodeSchema,
+        location_description: getStringValueRequiredSchema(50),
+        city: getStringValueRequiredSchema(80),
+        province: ProvinceNodeSchema,
+        locality: getStringValueSchema(50),
+        bc_property_legal_description: z.array(
+            BcPropertyLegalDescriptionTileSchema,
+        ),
+    }),
 });
 
 const requiredCivicAddressSchema = CivicAddressSchema.partial({
@@ -46,26 +39,29 @@ function getCivicAddress(): CivicAddressType {
 }
 class CivicAddress implements CivicAddressType {
     constructor() {
-        this.civicAddressId = crypto.randomUUID();
-        this.hasCivicAddress = true;
-        this.overrideAddress = false;
-        this.streetAddress = '';
-        this.city = '';
-        this.postalCode = '';
-        this.locality = '';
-        this.locationDescription = '';
-        this.legalDescriptions = <(typeof LegalDescription)[]>[];
+        this.aliased_data = {
+            civicAddressId: crypto.randomUUID(),
+            street_address: blankStringValue(),
+            postal_code: blankStringValue(),
+            location_description: blankStringValue(),
+            city: blankStringValue(),
+            province: blankConceptValue(),
+            locality: blankStringValue(),
+            bc_property_legal_description: blankStringValue(),
+            //legalDescriptions = <(typeof LegalDescription)[]>;
+        };
     }
-
-    civicAddressId: string;
-    hasCivicAddress: boolean;
-    overrideAddress: boolean;
-    streetAddress: string;
-    city: string;
-    postalCode: string;
-    locality: string;
-    locationDescription: string;
-    legalDescriptions: (typeof LegalDescription)[];
+    aliased_data: {
+        civicAddressId: StringValue;
+        street_address: StringValue;
+        postal_code: StringValue;
+        location_description: StringValue;
+        city: StringValue;
+        province: ConceptValue;
+        locality: StringValue;
+        bc_property_legal_description: StringValue;
+        //legalDescriptions: (typeof LegalDescription)[];
+    };
 }
 
 console.log(requiredCivicAddressSchema);
@@ -75,4 +71,5 @@ export {
     CivicAddressSchema,
     getCivicAddress,
     requiredCivicAddressSchema,
+    type CivicAddressType,
 };

--- a/bcrhp/src/bcrhp/schema/HeritageSiteSchema.ts
+++ b/bcrhp/src/bcrhp/schema/HeritageSiteSchema.ts
@@ -1,40 +1,45 @@
 import { z } from 'zod';
-import { CivicAddressSchema } from '@/bcrhp/schema/CivicAddressSchema.ts';
-import { SiteImagesSchema } from '@/bcrhp/schema/SiteImagesSchema.ts';
-import { RecognitionDetailsSchema } from '@/bcrhp/schema/RecognitionDetailsSchema.ts';
-import { StatementOfSignificanceSchema } from '@/bcrhp/schema/StatementOfSignificanceSchema.ts';
-import { SiteClassificationSchema } from '@/bcrhp/schema/SiteClassificationSchema.ts';
-import { SiteDetailsSchema } from '@/bcrhp/schema/SiteDetailsSchema.ts';
+import { getSiteImages } from '@/bcrhp/schema/SiteImagesSchema.ts';
+import { getStatementOfSignificance } from '@/bcrhp/schema/StatementOfSignificanceSchema.ts';
+import { blankResourceInstanceValue } from '@/bcrhp/utils.ts';
+import { SiteDocumentTileSchema } from '@bcrhp/schemas/heritage_site/site_document.ts';
+import { BordenNumberTileSchema } from '@bcrhp/schemas/heritage_site/borden_number.ts';
+import { ChildSitesTileSchema } from '@bcrhp/schemas/heritage_site/child_sites.ts';
+import { HeritageThemeTileSchema } from '@bcrhp/schemas/heritage_site/heritage_theme.ts';
+import { ExternalUrlTileSchema } from '@bcrhp/schemas/heritage_site/external_url.ts';
+import { SiteRecordAdminTileSchema } from '@bcrhp/schemas/heritage_site/site_record_admin.ts';
+import { InternalRemarkTileSchema } from '@bcrhp/schemas/heritage_site/internal_remark.ts';
+import { SiteImagesTileSchema } from '@bcrhp/schemas/heritage_site/site_images.ts';
+import { HeritageSiteLocationTileSchema } from '@bcrhp/schemas/heritage_site/heritage_site_location.ts';
+import { SiteNamesTileSchema } from '@bcrhp/schemas/heritage_site/site_names.ts';
+import { ChronologyTileSchema } from '@bcrhp/schemas/heritage_site/chronology.ts';
+import { BcRightTileSchema } from '@bcrhp/schemas/heritage_site/bc_right.ts';
+import { HeritageClassTileSchema } from '@bcrhp/schemas/heritage_site/heritage_class.ts';
+import { BcStatementOfSignificanceTileSchema } from '@bcrhp/schemas/heritage_site/bc_statement_of_significance.ts';
+import { HeritageFunctionTileSchema } from '@bcrhp/schemas/heritage_site/heritage_function.ts';
+import { ConstructionActorsTileSchema } from '@bcrhp/schemas/heritage_site/construction_actors.ts';
 
 const HeritageSiteSchema = z.object({
-    siteId: z.string().uuid(),
-    bordenNumber: z
-        .string()
-        .min(1, { message: 'Borden Number is required.' })
-        .refine(
-            (value: string) =>
-                /^[A-Z][a-z][A-Z][a-z]-[0-9]{1-4}$/.test(value ?? ''),
-            'Invalid Borden Number format.',
+    aliased_data: z.object({
+        site_document: z.array(SiteDocumentTileSchema),
+        borden_number: BordenNumberTileSchema,
+        child_sites: ChildSitesTileSchema,
+        heritage_theme: HeritageThemeTileSchema,
+        external_url: z.array(ExternalUrlTileSchema),
+        site_record_admin: z.array(SiteRecordAdminTileSchema),
+        internal_remark: z.array(InternalRemarkTileSchema),
+        site_images: z.array(SiteImagesTileSchema),
+        heritage_site_location: z.array(HeritageSiteLocationTileSchema),
+        site_names: z.array(SiteNamesTileSchema),
+        chronology: z.array(ChronologyTileSchema),
+        bc_right: BcRightTileSchema,
+        heritage_class: z.array(HeritageClassTileSchema),
+        bc_statement_of_significance: z.array(
+            BcStatementOfSignificanceTileSchema,
         ),
-    commonName: z
-        .string({
-            invalid_type_error: 'Common Name is required.',
-        })
-        .min(1, { message: 'Common Name is required.' })
-        .max(250),
-    otherNames: z.array(z.string()).max(5),
-    otherName: z.string().max(250).nullable(), // @todo - This shouldn't live here. Push names into own schema?
-    civicAddress: z.array(CivicAddressSchema),
-    civicAddresses: z.array(z.string()).max(5),
-    siteImages: z.array(SiteImagesSchema),
-    recognitionDetails: z.array(RecognitionDetailsSchema),
-    statementOfSignificance: z.array(StatementOfSignificanceSchema),
-    siteClassification: z.array(SiteClassificationSchema),
-    siteDetails: z.array(SiteDetailsSchema),
-    siteBoundary: z.object(), // This needs to map to a GeoJSON object
-    siteBoundaryIncorrect: z.boolean().default(false), // If the geometry from the PID isn't right this flags it
-    documentDescription: z.string().max(250),
-    submissionNotes: z.string().max(250),
+        heritage_function: z.array(HeritageFunctionTileSchema),
+        construction_actors: z.array(ConstructionActorsTileSchema),
+    }),
 });
 
 const requiredHeritageSiteSchema = HeritageSiteSchema.partial({
@@ -50,41 +55,43 @@ function getHeritageSite(): HeritageSiteType {
 // @todo - Figure out object state - New/Updated/Deleted
 class HeritageSite implements HeritageSiteType {
     constructor() {
-        this.siteId = crypto.randomUUID();
-        this.bordenNumber = '';
-        this.commonName = '';
-        this.otherNames = [];
-        this.hasCivicAddress = true;
-        this.civicAddress = {}; // Object of UUID -> CivicAddress objects
-        this.civicAddresses = [];
-        this.siteImages = {};
-        this.siteBoundary = {};
-        this.recognitionDetails = {};
-        this.statementOfSignificance = {};
-        this.siteClassification = {};
-        this.siteDetails = {};
-        this.siteBoundaryIncorrect = false;
-        this.otherName = '';
-        this.documentDescription = '';
-        this.submissionNotes = '';
+        this.aliased_data = {
+            site_document: blankResourceInstanceValue(),
+            borden_number: blankResourceInstanceValue(),
+            child_sites: blankResourceInstanceValue(),
+            heritage_theme: blankResourceInstanceValue(),
+            external_url: blankResourceInstanceValue(),
+            site_record_admin: blankResourceInstanceValue(),
+            internal_remark: blankResourceInstanceValue(),
+            site_images: getSiteImages(),
+            heritage_site_location: blankResourceInstanceValue(),
+            site_names: blankResourceInstanceValue(),
+            chronology: blankResourceInstanceValue(),
+            bc_right: blankResourceInstanceValue(),
+            heritage_class: blankResourceInstanceValue(),
+            bc_statement_of_significance: getStatementOfSignificance(),
+            heritage_function: blankResourceInstanceValue(),
+            construction_actors: blankResourceInstanceValue(),
+        };
     }
-    siteId: string;
-    bordenNumber: string;
-    commonName: string;
-    otherNames: string[];
-    hasCivicAddress: boolean;
-    civicAddress: typeof CivicAddressSchema;
-    civicAddresses: string[];
-    siteImages: typeof SiteImagesSchema;
-    recognitionDetails: typeof RecognitionDetailsSchema;
-    statementOfSignificance: typeof StatementOfSignificanceSchema;
-    siteClassification: typeof SiteClassificationSchema;
-    siteDetails: typeof SiteDetailsSchema;
-    siteBoundary: object;
-    siteBoundaryIncorrect: boolean;
-    otherName: string;
-    documentDescription: string;
-    submissionNotes: string;
+    aliased_data: {
+        site_document: typeof SiteDocumentTileSchema;
+        borden_number: typeof BordenNumberTileSchema;
+        child_sites: typeof ChildSitesTileSchema;
+        heritage_theme: typeof HeritageThemeTileSchema;
+        external_url: typeof ExternalUrlTileSchema;
+        site_record_admin: typeof SiteRecordAdminTileSchema;
+        internal_remark: typeof InternalRemarkTileSchema;
+        site_images: typeof SiteImagesTileSchema;
+        heritage_site_location: typeof HeritageSiteLocationTileSchema;
+        site_names: typeof SiteNamesTileSchema;
+        chronology: typeof ChronologyTileSchema;
+        bc_right: typeof BcRightTileSchema;
+        heritage_class: typeof HeritageClassTileSchema;
+        bc_statement_of_significance: typeof BcStatementOfSignificanceTileSchema;
+        heritage_function: typeof HeritageFunctionTileSchema;
+        construction_actors: typeof ConstructionActorsTileSchema;
+    };
 }
 
 console.log(requiredHeritageSiteSchema);
@@ -94,4 +101,5 @@ export {
     HeritageSite,
     getHeritageSite,
     requiredHeritageSiteSchema,
+    type HeritageSiteType,
 };

--- a/bcrhp/src/bcrhp/schema/LegalDescriptionSchema.ts
+++ b/bcrhp/src/bcrhp/schema/LegalDescriptionSchema.ts
@@ -1,21 +1,21 @@
 import { z } from 'zod';
+import type { StringValue } from '@/arches_component_lab/datatypes/string/types.ts';
+import type { NumberValue } from '@/arches_component_lab/datatypes/number/types.ts';
+import { blankStringValue } from '@/bcrhp/utils.ts';
+import {
+    LegalAddressInternalNotesNodeSchema,
+    PinNodeSchema,
+    PidNodeSchema,
+    LegalDescriptionNodeSchema,
+} from '@bcrhp/schemas/heritage_site/bc_property_legal_description.ts';
 
 const LegalDescriptionSchema = z.object({
-    pid: z.number().int().min(0).max(999999999),
-    pin: z.number().int().min(0).max(99999999),
-    legalDescription: z.string().max(250),
-    internalNotes: z.string(),
-    overrideAddress: z.boolean().default(false),
-    parcelId: z
-        .string()
-        .min(1, { message: 'Parcel Identifier is required.' })
-        .max(32)
-        .nullable(),
-    legalAddress: z
-        .string()
-        .min(1, { message: 'Legal Address is required.' })
-        .max(80)
-        .nullable(),
+    aliased_data: z.object({
+        legal_address_internal_notes: LegalAddressInternalNotesNodeSchema,
+        pin: PinNodeSchema,
+        pid: PidNodeSchema,
+        legal_description: LegalDescriptionNodeSchema,
+    }),
 });
 // @ts-ignore
 type LegalDescriptionType = z.infer<typeof LegalDescriptionSchema>;
@@ -28,22 +28,19 @@ function getLegalDescription(): LegalDescriptionType {
 
 class LegalDescription implements LegalDescriptionType {
     constructor() {
-        this.legalDescription = '';
-        this.internalNotes = '';
-        this.pid = 0;
-        this.pin = 0;
-        this.parcelId = '';
-        this.overrideLegalDescription = false;
-        this.legalAddress = '';
+        this.aliased_data = {
+            legal_address_internal_notes: blankStringValue(),
+            pin: blankStringValue(),
+            pid: blankStringValue(),
+            legal_description: blankStringValue(),
+        };
     }
-
-    legalDescription: string;
-    internalNotes: string;
-    pid: number;
-    pin: number;
-    parcelId: string;
-    overrideLegalDescription: boolean;
-    legalAddress: string;
+    aliased_data: {
+        legal_address_internal_notes: StringValue;
+        pin: NumberValue;
+        pid: NumberValue;
+        legal_description: StringValue;
+    };
 }
 
 export {
@@ -51,4 +48,5 @@ export {
     LegalDescriptionSchema,
     getLegalDescription,
     requiredLegalDescriptionSchema,
+    type LegalDescriptionType,
 };

--- a/bcrhp/src/bcrhp/schema/RecognitionDetailsSchema.ts
+++ b/bcrhp/src/bcrhp/schema/RecognitionDetailsSchema.ts
@@ -1,42 +1,33 @@
 import { z } from 'zod';
+import type { StringValue } from '@/arches_component_lab/datatypes/string/types.ts';
+import { blankStringValue, currentDateValue } from '@/bcrhp/utils.ts';
+import type { DateValue } from '@/arches_component_lab/datatypes/date/types.ts';
+import { getStringValueRequiredSchema } from '@/bcgov_arches_common/datatypes/string/validation/zod.ts';
+import {
+    ProtectionNotesNodeSchema,
+    DesignationOrProtectionStartDateNodeSchema,
+    DesignationOrProtectionEndDateNodeSchema,
+    ResponsibleGovernmentNodeSchema,
+    LegislativeActNodeSchema,
+} from '@bcrhp/schemas/heritage_site/protection_event.ts';
 
-const ConceptValue = z.object({
-    display_value: z.string(),
-    node_value: z.string().nullable(),
-    details: z.array(z.any()),
-});
-const CollectionItemSchema = z.object({
-    id: z.string(),
-    text: z.string(),
-    conceptId: z.string(),
-    sortOrder: z.string(),
-    children: z.array(z.any()),
-});
 const RecognitionDetailsSchema = z.object({
-    designationDate: ConceptValue,
-    legislativeAct: CollectionItemSchema,
-    referenceNumber: z
-        .string({
-            // This handles null values -> null !== typeof Date
-            invalid_type_error: 'Reference number is required.',
-        })
-        .min(1, { message: 'Reference Number is required.' })
-        .max(12),
-    totalRecognitionDetails: z.array(z.string()).max(12),
+    aliased_data: z.object({
+        protection_notes: ProtectionNotesNodeSchema,
+        designation_or_protection_start_date:
+            DesignationOrProtectionStartDateNodeSchema,
+        designation_or_protection_end_date:
+            DesignationOrProtectionEndDateNodeSchema,
+        responsible_government: ResponsibleGovernmentNodeSchema,
+        legislative_act: LegislativeActNodeSchema,
+        reference_number: getStringValueRequiredSchema(12),
+    }),
 });
 
-const requiredRecognitionDetailsSchema = RecognitionDetailsSchema.partial({
-    designationDate: true,
-    legislativeAct: true,
-    referenceNumber: true,
-});
+const requiredRecognitionDetailsSchema = RecognitionDetailsSchema.partial();
 
-// @ts-ignore
-type DateValueType = z.infer<typeof ConceptValue>;
 // @ts-ignore
 type RecognitionDetailsType = z.infer<typeof RecognitionDetailsSchema>;
-// @ts-ignore
-type CollectionItemType = z.infer<typeof CollectionItemSchema>;
 
 function getRecognitionDetails(): RecognitionDetailsType {
     return new RecognitionDetails();
@@ -45,15 +36,23 @@ function getRecognitionDetails(): RecognitionDetailsType {
 // @todo - Figure out object state - New/Updated/Deleted
 class RecognitionDetails implements RecognitionDetailsType {
     constructor() {
-        this.designationDate = null;
-        this.legislativeAct = null;
-        this.referenceNumber = '';
-        this.totalRecognitionDetails = [];
+        this.aliased_data = {
+            protection_notes: blankStringValue(),
+            designation_or_protection_start_date: currentDateValue(),
+            designation_or_protection_end_date: currentDateValue(),
+            responsible_government: blankStringValue(),
+            legislative_act: blankStringValue(),
+            reference_number: blankStringValue(),
+        };
     }
-    designationDate: DateValueType | null;
-    legislativeAct: CollectionItemType;
-    referenceNumber: string;
-    totalRecognitionDetails: string[];
+    aliased_data: {
+        protection_notes: StringValue;
+        designation_or_protection_start_date: DateValue;
+        designation_or_protection_end_date: DateValue;
+        responsible_government: StringValue;
+        legislative_act: StringValue;
+        reference_number: StringValue;
+    };
 }
 
 export {
@@ -61,4 +60,5 @@ export {
     RecognitionDetailsSchema,
     getRecognitionDetails,
     requiredRecognitionDetailsSchema,
+    type RecognitionDetailsType,
 };

--- a/bcrhp/src/bcrhp/schema/SiteClassificationSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteClassificationSchema.ts
@@ -1,61 +1,43 @@
 import { z } from 'zod';
+import type { StringValue } from '@/arches_component_lab/datatypes/string/types.ts';
+import type { NumberValue } from '@/arches_component_lab/datatypes/number/types.ts';
+import { blankResourceInstanceValue, blankStringValue } from '@/bcrhp/utils.ts';
+import { blankConceptValue } from '@/arches_component_lab/datatypes/concept/utils.ts';
+import type { ConceptValue } from '@/arches_component_lab/datatypes/concept/types.ts';
+import type { ResourceInstanceValue } from '@/arches_component_lab/datatypes/resource-instance/types.ts';
+import {
+    ContributingResourceCountNodeSchema,
+    OwnershipNodeSchema,
+    HeritageCategoryNodeSchema,
+} from '@bcrhp/schemas/heritage_site/heritage_class.ts';
+import {
+    FunctionalStateNodeSchema,
+    FunctionalCategoryNodeSchema,
+} from '@bcrhp/schemas/heritage_site/heritage_function.ts';
+import { HeritageThemeTileSchema } from '@bcrhp/schemas/heritage_site/heritage_theme.ts';
 
-const CollectionItemSchema = z.object({
-    id: z.string(),
-    text: z.string(),
-    conceptId: z.string(),
-    sortOrder: z.string(),
-    children: z.array(z.any()),
-});
-const ConceptOptionSchema = z.object({
-    id: z.string(),
-    conceptid: z.string(),
-    depth: z.number(),
-    language: z.string(),
-    text: z.string(),
-    type: z.string(),
-});
 const SiteClassificationSchema = z.object({
     heritageClasses: z.array(z.string()).max(5),
     heritageFunctions: z.array(z.string()).max(5),
     heritageThemes: z.array(z.string()).max(5),
 });
 const HeritageClassSchema = z.object({
-    contributingResources: z
-        .string()
-        .transform((val: string, ctx: any) => {
-            const parsed = parseInt(val, 10);
-
-            if (isNaN(parsed)) {
-                ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    message: 'Contributing Resources must be a valid number.',
-                });
-                return z.NEVER;
-            }
-
-            return parsed;
-        })
-        .refine((val: number) => val >= 1, {
-            message: 'Number of Contributing Resources is required.',
-        })
-        .refine((val: number) => val <= 250, {
-            message: 'Number of Contributing Resources must be 250 or less.',
-        }),
-    heritageCategory: ConceptOptionSchema,
-    ownership: ConceptOptionSchema,
+    aliased_data: z.object({
+        contributing_resource_count: ContributingResourceCountNodeSchema,
+        ownership: OwnershipNodeSchema,
+        heritage_category: HeritageCategoryNodeSchema,
+    }),
 });
 const HeritageFunctionSchema = z.object({
-    functionCategory: CollectionItemSchema,
-    functionCategoryType: z
-        .string({
-            invalid_type_error: 'Heritage Category Type is required.',
-        })
-        .min(1, { message: 'Heritage Category Type is required.' })
-        .max(250),
+    aliased_data: z.object({
+        functional_state: FunctionalStateNodeSchema,
+        functional_category: FunctionalCategoryNodeSchema,
+    }),
 });
 const HeritageThemeSchema = z.object({
-    heritageTheme: CollectionItemSchema,
+    aliased_data: z.object({
+        heritage_theme: z.array(HeritageThemeTileSchema),
+    }),
 });
 
 const requiredSiteClassificationSchema = SiteClassificationSchema.partial({});
@@ -63,10 +45,6 @@ const requiredHeritageClassSchema = HeritageClassSchema.partial({});
 const requiredHeritageFunctionSchema = HeritageFunctionSchema.partial({});
 const requiredHeritageThemeSchema = HeritageThemeSchema.partial({});
 
-// @ts-ignore
-type CollectionItemType = z.infer<typeof CollectionItemSchema>;
-// @ts-ignore
-type ConceptOptionType = z.infer<typeof ConceptOptionSchema>;
 // @ts-ignore
 type SiteClassificationType = z.infer<typeof SiteClassificationSchema>;
 // @ts-ignore
@@ -104,29 +82,41 @@ class SiteClassification implements SiteClassificationType {
 
 class HeritageClass implements HeritageClassType {
     constructor() {
-        this.contributingResources = 0;
-        this.heritageCategory = null;
-        this.ownership = null;
+        this.aliased_data = {
+            contributing_resource_count: blankStringValue(),
+            ownership: blankConceptValue(),
+            heritage_category: blankConceptValue(),
+        };
     }
-    contributingResources: number;
-    heritageCategory: ConceptOptionType;
-    ownership: ConceptOptionType;
+    aliased_data: {
+        contributing_resource_count: NumberValue;
+        ownership: ConceptValue;
+        heritage_category: ConceptValue;
+    };
 }
 
 class HeritageFunction implements HeritageFunctionType {
     constructor() {
-        this.functionCategory = null;
-        this.functionCategoryType = '';
+        this.aliased_data = {
+            functional_state: blankConceptValue(),
+            functional_category: blankStringValue(),
+        };
     }
-    functionCategory: CollectionItemType;
-    functionCategoryType: string;
+    aliased_data: {
+        functional_state: ConceptValue;
+        functional_category: StringValue;
+    };
 }
 
 class HeritageTheme implements HeritageThemeType {
     constructor() {
-        this.heritageTheme = null;
+        this.aliased_data = {
+            heritage_theme: blankResourceInstanceValue(),
+        };
     }
-    heritageTheme: CollectionItemType;
+    aliased_data: {
+        heritage_theme: ResourceInstanceValue;
+    };
 }
 
 export {
@@ -146,4 +136,7 @@ export {
     HeritageThemeSchema,
     getHeritageThemeSchema,
     requiredHeritageThemeSchema,
+    type HeritageClassType,
+    type HeritageFunctionType,
+    type HeritageThemeType,
 };

--- a/bcrhp/src/bcrhp/schema/SiteDetailsSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteDetailsSchema.ts
@@ -1,61 +1,59 @@
 import { z } from 'zod';
+import type { StringValue } from '@/arches_component_lab/datatypes/string/types.ts';
+import type { DateValue } from '@/arches_component_lab/datatypes/date/types.ts';
+import { blankStringValue, currentDateValue } from '@/bcrhp/utils.ts';
+import type { ConceptValue } from '@/arches_component_lab/datatypes/concept/types.ts';
+import type { URLValue } from '@/arches_component_lab/datatypes/url/types.ts';
+import { ConceptValueRequiredSchema } from '@/bcgov_arches_common/datatypes/concept/validation/zod.ts';
+import { blankConceptValue } from '@/arches_component_lab/datatypes/concept/utils.ts';
+import {
+    StartYearNodeSchema,
+    EndYearNodeSchema,
+} from '@bcrhp/schemas/heritage_site/construction_actors.ts';
+import { ConstructionActorTypeNodeSchema } from '@bcrhp/schemas/heritage_site/construction_actors.ts';
+import {
+    getStringValueSchema,
+    getStringValueRequiredSchema,
+} from '@/bcgov_arches_common/datatypes/string/validation/zod.ts';
+import { ExternalUrlTypeNodeSchema } from '@bcrhp/schemas/heritage_site/external_url.ts';
 
-const ConceptValue = z.object({
-    display_value: z.string(),
-    node_value: z.string().nullable(),
-    details: z.array(z.any()),
-});
-const CollectionItemSchema = z.object({
-    id: z.string(),
-    text: z.string(),
-    conceptId: z.string(),
-    sortOrder: z.string(),
-    children: z.array(z.any()),
-});
 const SiteDetailsSchema = z.object({
     chronologies: z.array(z.string()).max(5),
     architectsOrBuilders: z.array(z.string()).max(5),
     urls: z.array(z.string()).max(5),
 });
 const ChronologySchema = z.object({
-    eventType: CollectionItemSchema,
-    startYear: ConceptValue,
-    endYear: ConceptValue,
-    circa: z.string().max(20).nullable(),
-    chronologyNotes: z.string().max(1000).nullable(),
+    aliased_data: z.object({
+        start_year: StartYearNodeSchema,
+        dates_approximate: z.boolean().default(false),
+        information_source: getStringValueSchema(250),
+        chronology: z.array(ConceptValueRequiredSchema),
+        chronology_notes: getStringValueSchema(250),
+        end_year: EndYearNodeSchema,
+    }),
 });
-const ArchitectBuilderSchema = z.object({
-    architectOrBuilderName: z
-        .string({
-            invalid_type_error: 'Architect or Builder Name is required.',
-        })
-        .min(1, { message: 'Architect or Builder Name is required.' })
-        .max(250),
-    architectOrBuilderNotes: z.string().max(4000).nullable(),
-    architectOrBuilderType: CollectionItemSchema,
+const ConstructionActorsTileSchema = z.object({
+    aliased_data: z.object({
+        construction_actor_notes: getStringValueSchema(250),
+        construction_actor: getStringValueRequiredSchema(250),
+        construction_actor_type: ConstructionActorTypeNodeSchema,
+    }),
 });
 
 const URLsSchema = z.object({
-    urlType: CollectionItemSchema,
-    linkText: z
-        .string({ invalid_type_error: 'Link Text is required.' })
-        .min(1, { message: 'Link Text is required.' })
-        .max(250),
-    url: z
-        .string({ invalid_type_error: 'URL is required.' })
-        .min(1, { message: 'URL is required.' })
-        .max(250),
+    aliased_data: z.object({
+        external_url_type: ExternalUrlTypeNodeSchema,
+        external_url: z.array(ExternalUrlTileSchema),
+        //link_text ?
+    }),
 });
 
 const requiredSiteDetailsSchema = SiteDetailsSchema.partial({});
 const requiredChronologySchema = ChronologySchema.partial({});
-const requiredArchitectBuilderSchema = ArchitectBuilderSchema.partial({});
+const requiredConstructionActorsTileSchema =
+    ConstructionActorsTileSchema.partial({});
 const requiredURLsSchema = URLsSchema.partial({});
 
-// @ts-ignore
-type DateValueType = z.infer<typeof ConceptValue>;
-// @ts-ignore
-type CollectionItemType = z.infer<typeof CollectionItemSchema>;
 // @ts-ignore
 type SiteDetailsType = z.infer<typeof SiteDetailsSchema>;
 // @ts-ignore
@@ -91,37 +89,49 @@ class SiteDetails implements SiteDetailsType {
 }
 class Chronology implements ChronologyType {
     constructor() {
-        this.eventType = null;
-        this.startYear = null;
-        this.endYear = null;
-        this.circa = false;
-        this.chronologyNotes = '';
+        this.aliased_data = {
+            start_year: currentDateValue(),
+            dates_approximate: false,
+            information_source: blankStringValue(),
+            chronology: blankConceptValue(),
+            chronology_notes: blankStringValue(),
+            end_year: currentDateValue(),
+        };
     }
-    eventType: CollectionItemType;
-    startYear: DateValueType | null;
-    endYear: DateValueType | null;
-    circa: boolean;
-    chronologyNotes: string;
+    aliased_data: {
+        start_year: DateValue;
+        dates_approximate: boolean;
+        information_source: StringValue;
+        chronology: ConceptValue;
+        chronology_notes: StringValue;
+        end_year: DateValue;
+    };
 }
 class ArchitectOrBuilder implements ArchitectOrBuilderType {
     constructor() {
-        this.architectOrBuilderName = '';
-        this.architectOrBuilderNotes = '';
-        this.architectOrBuilderType = null;
+        this.aliased_data = {
+            construction_actor_notes: blankStringValue(),
+            construction_actor: blankStringValue(),
+            construction_actor_type: blankConceptValue(),
+        };
     }
-    architectOrBuilderName: string;
-    architectOrBuilderNotes: string;
-    architectOrBuilderType: CollectionItemType;
+    aliased_data: {
+        construction_actor_notes: StringValue;
+        construction_actor: StringValue;
+        construction_actor_type: ConceptValue;
+    };
 }
 class URLs implements URLsType {
     constructor() {
-        this.urlType = null;
-        this.linkText = '';
-        this.url = '';
+        this.aliased_data = {
+            external_url_type: blankConceptValue(),
+            external_url: blankStringValue(),
+        };
     }
-    urlType: CollectionItemType;
-    linkText: string;
-    url: string;
+    aliased_data: {
+        external_url_type: ConceptValue;
+        external_url: URLValue;
+    };
 }
 
 export {
@@ -134,11 +144,15 @@ export {
     getChronologySchema,
     requiredChronologySchema,
     ArchitectOrBuilder,
-    ArchitectBuilderSchema,
+    ConstructionActorsTileSchema,
     getArchitectOrBuilderSchema,
-    requiredArchitectBuilderSchema,
+    requiredConstructionActorsTileSchema,
     URLs,
     URLsSchema,
     getURLsSchema,
     requiredURLsSchema,
+    type SiteDetailsType,
+    type ChronologyType,
+    type ArchitectOrBuilderType,
+    type URLsType,
 };

--- a/bcrhp/src/bcrhp/schema/SiteImagesSchema.ts
+++ b/bcrhp/src/bcrhp/schema/SiteImagesSchema.ts
@@ -1,36 +1,41 @@
 import { z } from 'zod';
-
-const ConceptValue = z.object({
-    display_value: z.string(),
-    node_value: z.string().nullable(),
-    details: z.array(z.any()),
-});
-const CollectionItemSchema = z.object({
-    id: z.string(),
-    text: z.string(),
-    conceptId: z.string(),
-    sortOrder: z.string(),
-    children: z.array(z.any()),
-});
+import type { StringValue } from '@/arches_component_lab/datatypes/string/types.ts';
+import {
+    currentDateValue,
+    blankStringValue,
+    blankFileListValue,
+} from '@/bcrhp/utils.ts';
+import { blankConceptValue } from '@/arches_component_lab/datatypes/concept/utils.ts';
+import type { ConceptValue } from '@/arches_component_lab/datatypes/concept/types.ts';
+import type { FileListValue } from '@/arches_component_lab/datatypes/file-list/types.ts';
+import { FileListValueSchema } from '@/bcgov_arches_common/datatypes/file-list/validation/zod.ts';
+import type { DateValue } from '@/arches_component_lab/datatypes/date/types.ts';
+import {
+    getStringValueSchema,
+    getStringValueRequiredSchema,
+} from '@/bcgov_arches_common/datatypes/string/validation/zod.ts';
+import {
+    ImageTypeNodeSchema,
+    ImageDateNodeSchema,
+    ImageViewNodeSchema,
+} from '@bcrhp/schemas/heritage_site/site_images.ts';
 const SiteImagesSchema = z.object({
-    imageType: CollectionItemSchema,
-    imageView: CollectionItemSchema,
-    imageFeatures: z.string().max(250).nullable(),
-    imageDate: ConceptValue,
-    imageDescription: z
-        .string({ invalid_type_error: 'Image Type is required.' })
-        .min(1, { message: 'Image Description is required.' })
-        .max(250),
-    photographer: z.string().max(250).nullable(),
-    copyright: z.string().max(250).nullable(),
+    aliased_data: z.object({
+        image_type: ImageTypeNodeSchema,
+        site_images: z.array(FileListValueSchema),
+        image_date: ImageDateNodeSchema,
+        image_features: getStringValueSchema(250),
+        image_description: getStringValueRequiredSchema(250),
+        primary_image: z.boolean().default(true),
+        image_view: ImageViewNodeSchema,
+        photographer: getStringValueSchema(250),
+        submit_to_crhp: z.boolean().default(false),
+        copyright: getStringValueSchema(250),
+    }),
 });
 
 const requiredSiteImagesSchema = SiteImagesSchema.partial({});
 
-// @ts-ignore
-type DateValueType = z.infer<typeof ConceptValue>;
-// @ts-ignore
-type CollectionItemType = z.infer<typeof CollectionItemSchema>;
 // @ts-ignore
 type SiteImagesType = z.infer<typeof SiteImagesSchema>;
 
@@ -41,23 +46,31 @@ function getSiteImages(): SiteImagesType {
 // @todo - Figure out object state - New/Updated/Deleted
 class SiteImages implements SiteImagesType {
     constructor() {
-        this.id = crypto.randomUUID();
-        this.imageType = null;
-        this.imageView = null;
-        this.imageFeatures = '';
-        this.imageDate = null;
-        this.imageDescription = '';
-        this.photographer = '';
-        this.copyright = '';
+        this.aliased_data = {
+            image_type: blankConceptValue(),
+            site_images: blankFileListValue(),
+            image_date: currentDateValue(),
+            image_features: blankStringValue(),
+            image_description: blankStringValue(),
+            primary_image: true,
+            image_view: blankConceptValue(),
+            photographer: blankStringValue(),
+            submit_to_crhp: false,
+            copyright: blankStringValue(),
+        };
     }
-    id: string;
-    imageType: CollectionItemType;
-    imageView: CollectionItemType;
-    imageFeatures: string;
-    imageDate: DateValueType | null;
-    imageDescription: string;
-    photographer: string;
-    copyright: string;
+    aliased_data: {
+        image_type: ConceptValue;
+        site_images: FileListValue;
+        image_date: DateValue;
+        image_features: StringValue;
+        image_description: StringValue;
+        primary_image: boolean;
+        image_view: ConceptValue;
+        photographer: StringValue;
+        submit_to_crhp: boolean;
+        copyright: StringValue;
+    };
 }
 
 export {
@@ -65,4 +78,5 @@ export {
     SiteImagesSchema,
     getSiteImages,
     requiredSiteImagesSchema,
+    type SiteImagesType,
 };

--- a/bcrhp/src/bcrhp/schema/StatementOfSignificanceSchema.ts
+++ b/bcrhp/src/bcrhp/schema/StatementOfSignificanceSchema.ts
@@ -1,30 +1,20 @@
 import { z } from 'zod';
+import type { StringValue } from '@/arches_component_lab/datatypes/string/types.ts';
+import type { ConceptValue } from '@/arches_component_lab/datatypes/concept/types.ts';
+import { blankConceptValue } from '@/arches_component_lab/datatypes/concept/utils.ts';
+import { blankStringValue } from '@/bcrhp/utils.ts';
+import { getRichTextValueRequiredSchema } from '@/bcgov_arches_common/datatypes/string/validation/zod.ts';
+import { getStringValueRequiredSchema } from '@/bcgov_arches_common/datatypes/string/validation/zod.ts';
+import { SignificanceTypeNodeSchema } from '@bcrhp/schemas/heritage_site/bc_statement_of_significance.ts';
 
 const StatementOfSignificanceSchema = z.object({
-    description: z
-        .string({
-            invalid_type_error: 'Description is required.',
-        })
-        .min(1, { message: 'Description is required.' })
-        .max(4000),
-    heritageValue: z
-        .string({
-            invalid_type_error: 'Heritage Value is required.',
-        })
-        .min(1, { message: 'Heritage Value is required.' })
-        .max(4000),
-    definingElements: z
-        .string({
-            invalid_type_error: 'Defining Elements is required.',
-        })
-        .min(1, { message: 'Defining Elements is required.' })
-        .max(4000),
-    documentLocation: z
-        .string({
-            invalid_type_error: 'Document Location is required.',
-        })
-        .min(1, { message: 'Document Location is required.' })
-        .max(250),
+    aliased_data: z.object({
+        heritage_value: getRichTextValueRequiredSchema(4000),
+        defining_elements: getRichTextValueRequiredSchema(4000),
+        physical_description: getRichTextValueRequiredSchema(4000),
+        significance_type: SignificanceTypeNodeSchema,
+        document_location: getStringValueRequiredSchema(250),
+    }),
 });
 
 const requiredStatementOfSignificanceSchema =
@@ -41,15 +31,21 @@ function getStatementOfSignificance(): StatementOfSignificanceType {
 // @todo - Figure out object state - New/Updated/Deleted
 class StatementOfSignificance implements StatementOfSignificanceType {
     constructor() {
-        this.description = '';
-        this.heritageValue = '';
-        this.definingElements = '';
-        this.documentLocation = '';
+        this.aliased_data = {
+            heritage_value: blankStringValue(),
+            defining_elements: blankStringValue(),
+            physical_description: blankStringValue(),
+            significance_type: blankConceptValue(),
+            document_location: blankStringValue(),
+        };
     }
-    description: string;
-    heritageValue: string;
-    definingElements: string;
-    documentLocation: string;
+    aliased_data: {
+        heritage_value: StringValue;
+        defining_elements: StringValue;
+        physical_description: StringValue;
+        significance_type: ConceptValue;
+        document_location: StringValue;
+    };
 }
 
 export {
@@ -57,4 +53,5 @@ export {
     StatementOfSignificanceSchema,
     getStatementOfSignificance,
     requiredStatementOfSignificanceSchema,
+    type StatementOfSignificanceType,
 };

--- a/bcrhp/src/bcrhp/schemas/heritage_site.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site.ts
@@ -2,83 +2,83 @@ import { z } from 'zod';
 import {
     SiteDocumentTileSchema,
     type SiteDocumentTileType,
-} from '@bcrhp/schemas/heritage_site/site_document.ts';
+} from '@/bcrhp/schemas/heritage_site/site_document.ts';
 import {
     BordenNumberTileSchema,
     type BordenNumberTileType,
-} from '@bcrhp/schemas/heritage_site/borden_number.ts';
+} from '@/bcrhp/schemas/heritage_site/borden_number.ts';
 import {
     ChildSitesTileSchema,
     type ChildSitesTileType,
-} from '@bcrhp/schemas/heritage_site/child_sites.ts';
+} from '@/bcrhp/schemas/heritage_site/child_sites.ts';
 import {
     HeritageThemeTileSchema,
     type HeritageThemeTileType,
-} from '@bcrhp/schemas/heritage_site/heritage_theme.ts';
+} from '@/bcrhp/schemas/heritage_site/heritage_theme.ts';
 import {
     ExternalUrlTileSchema,
     type ExternalUrlTileType,
-} from '@bcrhp/schemas/heritage_site/external_url.ts';
+} from '@/bcrhp/schemas/heritage_site/external_url.ts';
 import {
     SiteRecordAdminTileSchema,
     type SiteRecordAdminTileType,
-} from '@bcrhp/schemas/heritage_site/site_record_admin.ts';
+} from '@/bcrhp/schemas/heritage_site/site_record_admin.ts';
 import {
     InternalRemarkTileSchema,
     type InternalRemarkTileType,
-} from '@bcrhp/schemas/heritage_site/internal_remark.ts';
+} from '@/bcrhp/schemas/heritage_site/internal_remark.ts';
 import {
     SiteImagesTileSchema,
     type SiteImagesTileType,
-} from '@bcrhp/schemas/heritage_site/site_images.ts';
+} from '@/bcrhp/schemas/heritage_site/site_images.ts';
 import {
     BcPropertyLegalDescriptionTileSchema,
     type BcPropertyLegalDescriptionTileType,
-} from '@bcrhp/schemas/heritage_site/bc_property_legal_description.ts';
+} from '@/bcrhp/schemas/heritage_site/bc_property_legal_description.ts';
 import {
     BcPropertyAddressTileSchema,
     type BcPropertyAddressTileType,
-} from '@bcrhp/schemas/heritage_site/bc_property_address.ts';
+} from '@/bcrhp/schemas/heritage_site/bc_property_address.ts';
 import {
     SiteBoundaryTileSchema,
     type SiteBoundaryTileType,
-} from '@bcrhp/schemas/heritage_site/site_boundary.ts';
+} from '@/bcrhp/schemas/heritage_site/site_boundary.ts';
 import {
     HeritageSiteLocationTileSchema,
     type HeritageSiteLocationTileType,
-} from '@bcrhp/schemas/heritage_site/heritage_site_location.ts';
+} from '@/bcrhp/schemas/heritage_site/heritage_site_location.ts';
 import {
     SiteNamesTileSchema,
     type SiteNamesTileType,
-} from '@bcrhp/schemas/heritage_site/site_names.ts';
+} from '@/bcrhp/schemas/heritage_site/site_names.ts';
 import {
     ChronologyTileSchema,
     type ChronologyTileType,
-} from '@bcrhp/schemas/heritage_site/chronology.ts';
+} from '@/bcrhp/schemas/heritage_site/chronology.ts';
 import {
     ProtectionEventTileSchema,
     type ProtectionEventTileType,
-} from '@bcrhp/schemas/heritage_site/protection_event.ts';
+} from '@/bcrhp/schemas/heritage_site/protection_event.ts';
 import {
     BcRightTileSchema,
     type BcRightTileType,
-} from '@bcrhp/schemas/heritage_site/bc_right.ts';
+} from '@/bcrhp/schemas/heritage_site/bc_right.ts';
 import {
     HeritageClassTileSchema,
     type HeritageClassTileType,
-} from '@bcrhp/schemas/heritage_site/heritage_class.ts';
+} from '@/bcrhp/schemas/heritage_site/heritage_class.ts';
 import {
     BcStatementOfSignificanceTileSchema,
     type BcStatementOfSignificanceTileType,
-} from '@bcrhp/schemas/heritage_site/bc_statement_of_significance.ts';
+} from '@/bcrhp/schemas/heritage_site/bc_statement_of_significance.ts';
 import {
     HeritageFunctionTileSchema,
     type HeritageFunctionTileType,
-} from '@bcrhp/schemas/heritage_site/heritage_function.ts';
+} from '@/bcrhp/schemas/heritage_site/heritage_function.ts';
 import {
     ConstructionActorsTileSchema,
     type ConstructionActorsTileType,
-} from '@bcrhp/schemas/heritage_site/construction_actors.ts';
+} from '@/bcrhp/schemas/heritage_site/construction_actors.ts';
 
 export const HeritageSiteSchema = z.object({
     resourceinstanceid: z.string().nullable(),
@@ -104,5 +104,5 @@ export const HeritageSiteSchema = z.object({
         construction_actors: z.array(ConstructionActorsTileSchema),
     }),
 });
-
+// @ts-ignore
 export type HeritageSiteType = z.infer<typeof HeritageSiteSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/bc_property_address.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/bc_property_address.ts
@@ -50,10 +50,14 @@ export const BcPropertyAddressTileSchema = z.object({
         city: CityNodeSchema,
         province: ProvinceNodeSchema,
         locality: LocalityNodeSchema,
-        bc_property_legal_description: z.array(BcPropertyLegalDescriptionTileSchema),
+        bc_property_legal_description: z.array(
+            BcPropertyLegalDescriptionTileSchema,
+        ),
     }),
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
-export type BcPropertyAddressTileType = z.infer<typeof BcPropertyAddressTileSchema>;
+// @ts-ignore
+export type BcPropertyAddressTileType = z.infer<
+    typeof BcPropertyAddressTileSchema
+>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/bc_property_legal_description.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/bc_property_legal_description.ts
@@ -40,5 +40,7 @@ export const BcPropertyLegalDescriptionTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
-export type BcPropertyLegalDescriptionTileType = z.infer<typeof BcPropertyLegalDescriptionTileSchema>;
+// @ts-ignore
+export type BcPropertyLegalDescriptionTileType = z.infer<
+    typeof BcPropertyLegalDescriptionTileSchema
+>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/bc_right.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/bc_right.ts
@@ -34,5 +34,5 @@ export const BcRightTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type BcRightTileType = z.infer<typeof BcRightTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/bc_statement_of_significance.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/bc_statement_of_significance.ts
@@ -47,5 +47,7 @@ export const BcStatementOfSignificanceTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
-export type BcStatementOfSignificanceTileType = z.infer<typeof BcStatementOfSignificanceTileSchema>;
+// @ts-ignore
+export type BcStatementOfSignificanceTileType = z.infer<
+    typeof BcStatementOfSignificanceTileSchema
+>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/borden_number.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/borden_number.ts
@@ -13,5 +13,5 @@ export const BordenNumberTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type BordenNumberTileType = z.infer<typeof BordenNumberTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/child_sites.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/child_sites.ts
@@ -13,5 +13,5 @@ export const ChildSitesTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type ChildSitesTileType = z.infer<typeof ChildSitesTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/chronology.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/chronology.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ConceptValueRequiredSchema } from '@/bcgov_arches_common/datatypes/concept/validation/zod.ts';
 
 // Auto-generated tile schema for alias: chronology
 
@@ -41,12 +42,12 @@ export const ChronologyTileSchema = z.object({
         start_year: StartYearNodeSchema,
         dates_approximate: DatesApproximateNodeSchema,
         information_source: InformationSourceNodeSchema,
-        chronology: z.array(ChronologyTileSchema),
+        chronology: z.array(ConceptValueRequiredSchema),
         chronology_notes: ChronologyNotesNodeSchema,
         end_year: EndYearNodeSchema,
     }),
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type ChronologyTileType = z.infer<typeof ChronologyTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/construction_actors.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/construction_actors.ts
@@ -33,5 +33,7 @@ export const ConstructionActorsTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
-export type ConstructionActorsTileType = z.infer<typeof ConstructionActorsTileSchema>;
+// @ts-ignore
+export type ConstructionActorsTileType = z.infer<
+    typeof ConstructionActorsTileSchema
+>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/external_url.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/external_url.ts
@@ -20,5 +20,5 @@ export const ExternalUrlTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type ExternalUrlTileType = z.infer<typeof ExternalUrlTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/heritage_class.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/heritage_class.ts
@@ -33,5 +33,5 @@ export const HeritageClassTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type HeritageClassTileType = z.infer<typeof HeritageClassTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/heritage_function.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/heritage_function.ts
@@ -26,5 +26,7 @@ export const HeritageFunctionTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
-export type HeritageFunctionTileType = z.infer<typeof HeritageFunctionTileSchema>;
+// @ts-ignore
+export type HeritageFunctionTileType = z.infer<
+    typeof HeritageFunctionTileSchema
+>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/heritage_site_location.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/heritage_site_location.ts
@@ -14,5 +14,7 @@ export const HeritageSiteLocationTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
-export type HeritageSiteLocationTileType = z.infer<typeof HeritageSiteLocationTileSchema>;
+// @ts-ignore
+export type HeritageSiteLocationTileType = z.infer<
+    typeof HeritageSiteLocationTileSchema
+>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/heritage_theme.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/heritage_theme.ts
@@ -13,5 +13,5 @@ export const HeritageThemeTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type HeritageThemeTileType = z.infer<typeof HeritageThemeTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/internal_remark.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/internal_remark.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-
+import { getRichTextValueSchema } from '@/bcgov_arches_common/datatypes/string/validation/zod.ts';
 // Auto-generated tile schema for alias: internal_remark
 
 const RemarkDateNodeSchema = z.object({
@@ -22,10 +22,10 @@ export const InternalRemarkTileSchema = z.object({
     aliased_data: z.object({
         remark_date: RemarkDateNodeSchema,
         remark_type: RemarkTypeNodeSchema,
-        internal_remark: z.array(InternalRemarkTileSchema),
+        internal_remark: z.array(getRichTextValueSchema(1000)),
     }),
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type InternalRemarkTileType = z.infer<typeof InternalRemarkTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/protection_event.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/protection_event.ts
@@ -45,8 +45,10 @@ export const ProtectionEventTileSchema = z.object({
     parenttile: z.string().nullable(),
     aliased_data: z.object({
         protection_notes: ProtectionNotesNodeSchema,
-        designation_or_protection_start_date: DesignationOrProtectionStartDateNodeSchema,
-        designation_or_protection_end_date: DesignationOrProtectionEndDateNodeSchema,
+        designation_or_protection_start_date:
+            DesignationOrProtectionStartDateNodeSchema,
+        designation_or_protection_end_date:
+            DesignationOrProtectionEndDateNodeSchema,
         responsible_government: ResponsibleGovernmentNodeSchema,
         legislative_act: LegislativeActNodeSchema,
         reference_number: ReferenceNumberNodeSchema,
@@ -55,4 +57,5 @@ export const ProtectionEventTileSchema = z.object({
     provisionaledits: z.unknown().nullable(),
 });
 
+// @ts-ignore
 export type ProtectionEventTileType = z.infer<typeof ProtectionEventTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/site_boundary.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/site_boundary.ts
@@ -27,5 +27,5 @@ export const SiteBoundaryTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type SiteBoundaryTileType = z.infer<typeof SiteBoundaryTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/site_document.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/site_document.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { FileListValueSchema } from '@/bcgov_arches_common/datatypes/file-list/validation/zod.ts';
 
 // Auto-generated tile schema for alias: site_document
 
@@ -20,12 +21,12 @@ export const SiteDocumentTileSchema = z.object({
     nodegroup: z.string().nullable(),
     parenttile: z.string().nullable(),
     aliased_data: z.object({
-        site_document: z.array(SiteDocumentTileSchema),
+        site_document: z.array(FileListValueSchema),
         document_description: DocumentDescriptionNodeSchema,
         document_type: DocumentTypeNodeSchema,
     }),
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type SiteDocumentTileType = z.infer<typeof SiteDocumentTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/site_images.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/site_images.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-
+import { FileListValueSchema } from '@/bcgov_arches_common/datatypes/file-list/validation/zod.ts';
 // Auto-generated tile schema for alias: site_images
 
 const ImageTypeNodeSchema = z.object({
@@ -63,7 +63,7 @@ export const SiteImagesTileSchema = z.object({
     parenttile: z.string().nullable(),
     aliased_data: z.object({
         image_type: ImageTypeNodeSchema,
-        site_images: z.array(SiteImagesTileSchema),
+        site_images: z.array(FileListValueSchema),
         image_date: ImageDateNodeSchema,
         image_features: ImageFeaturesNodeSchema,
         image_description: ImageDescriptionNodeSchema,
@@ -76,5 +76,5 @@ export const SiteImagesTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type SiteImagesTileType = z.infer<typeof SiteImagesTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/site_names.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/site_names.ts
@@ -26,5 +26,5 @@ export const SiteNamesTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type SiteNamesTileType = z.infer<typeof SiteNamesTileSchema>;

--- a/bcrhp/src/bcrhp/schemas/heritage_site/site_record_admin.ts
+++ b/bcrhp/src/bcrhp/schemas/heritage_site/site_record_admin.ts
@@ -47,5 +47,5 @@ export const SiteRecordAdminTileSchema = z.object({
     sortorder: z.number().nullable(),
     provisionaledits: z.unknown().nullable(),
 });
-
+// @ts-ignore
 export type SiteRecordAdminTileType = z.infer<typeof SiteRecordAdminTileSchema>;


### PR DESCRIPTION
This PR is a work in progress. It updates the BCRHP Zod schema to match the arches-querysets schema. Additionally, it resolves typescript / ESlint CI errors (not all, view notes below).

NOTES:
- js-cookie 3.0.5 causes build errors, reverted to 2.2.1
- tsconfig paths cause TS type errors (bcgov_arches_common in particular)

TODO: 
- Update each step to use GenericWidget (Replace PrimeVue's InputText and Editor widgets etc.)
- Update each step to use new aliased_data structure, with GenericWidget (Step6_SOS has been updated, but is not using GenericWidget)
- _Maybe_ move utils.ts into arches-common so that bcfms and bcrhp can reuse it. Contents are identical

AUTO GENERATED FILES (from resource models, these schema may not exist?):
- external_url -> external_url, what is url type schema?
- bc_property_address -> bc_property_legal_description, what is semantic type schema?
- bc_rights -> protection event, what is semantic type schema?
- child_sites -> what is resource-instance-list type schema?
- heritage_site_location -> site_boundary, what is geojson-feature-collection type schema?
- heritage_site_location -> bc_property_address, what is semantic type schema?
- heritage_theme -> heritage_theme, what is concept-list type schema?
- site_boundary -> site_boundary, what is geojson-feature-collection type schema?
