### PR TITLE
Testing fixes2

### DIFF
--- a/bcrhp/src/bcrhp/pages/NewSite/NewSite.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/NewSite.vue
@@ -359,6 +359,7 @@ const showDebug = ref(false);
                             <ReviewSubmission
                                 ref="step11"
                                 :submission-errors="submissionErrors"
+                                :submissionComplete="false"
                                 @update:step-is-valid="
                                     setCurrentStepValid($event, 11)
                                 "
@@ -369,6 +370,7 @@ const showDebug = ref(false);
                             <ReviewSubmission
                                 ref="step12"
                                 :submission-errors="submissionErrors"
+                                :submissionComplete="true"
                                 @update:step-is-valid="
                                     setCurrentStepValid($event, 12)
                                 "
@@ -397,20 +399,51 @@ const showDebug = ref(false);
     aside,
     .bcgov-vertical-steps,
     .stepper-nav-panel,
-    .sidenav {
+    .sidenav,
+    .debug-toggle {
         display: none !important;
     }
+
     html,
     body {
         height: auto !important;
         overflow: visible !important;
     }
+
     .main-content-area,
     .page-wrapper,
     main {
         position: static !important;
         overflow: visible !important;
         height: auto !important;
+        width: 100% !important;
+        max-width: 100% !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        display: block !important;
+    }
+
+    .bcgov-stepper,
+    .bcgov-vertical-step-panels {
+        display: block !important;
+        width: 100% !important;
+        max-width: 100% !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        flex: none !important;
+    }
+
+    .p-panel,
+    .p-panel-content,
+    .p-panel-header {
+        padding-top: 0 !important;
+        margin-top: 0 !important;
+        border: none !important;
+    }
+
+    .bcgov-vertical-step-panels h1 {
+        margin-top: 0 !important;
+        padding-top: 0 !important;
     }
 }
 .red {

--- a/bcrhp/src/bcrhp/pages/NewSite/NewSite.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/NewSite.vue
@@ -234,6 +234,13 @@ const showDebug = ref(false);
                         districts to submit a notice of new heritage property to
                         the BC Register of Historic Places
                     </p>
+                    <p v-if="currentStep >= 6 && currentStep <= 9">
+                        Although this Step is not required to complete a
+                        submission, if you complete any portion of this Step,
+                        you must fully complete all required fields for this
+                        Step. Refer to the manual for detailed instructions and
+                        field definitions.
+                    </p>
                     <StepPanels>
                         <StepperNavigation
                             :step-number="currentStep"

--- a/bcrhp/src/bcrhp/pages/NewSite/steps/Step10_SupportingDocuments.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/steps/Step10_SupportingDocuments.vue
@@ -111,6 +111,7 @@ defineExpose({ isValid });
 <template>
     <Form
         ref="supportingDocumentsForm"
+        v-slot="$form"
         name="supportingDocumentsForm"
         :validateOnBlur="true"
         :resolver="supportingDocumentsResolver"
@@ -142,58 +143,68 @@ defineExpose({ isValid });
                     </ul>
                 </div>
             </div>
-            <div>
-                <div>
-                    <GenericWidget
-                        :key="siteDocumentKey"
-                        graph-slug="heritage_site"
-                        node-alias="site_document"
-                        :should-show-label="true"
-                        :mode="EDIT"
-                        :aliased-node-data="
-                            siteDocument.value?.aliased_data?.site_document
-                        "
-                        @update:value="
-                            updateModelValue($event, 'site_document')
-                        "
-                    ></GenericWidget>
-                </div>
-                <br />
-                <div>
-                    <GenericWidget
-                        :key="siteDocumentKey"
-                        graph-slug="heritage_site"
-                        node-alias="document_type"
-                        :should-show-label="true"
-                        :mode="EDIT"
-                        :card-x-node-x-widget-data-overrides="
-                            documentTypeOverrides
-                        "
-                        :aliased-node-data="
-                            siteDocument.value?.aliased_data?.document_type
-                        "
-                        @update:value="
-                            updateModelValue($event, 'document_type')
-                        "
-                    ></GenericWidget>
-                    <br />
-                    <GenericWidget
-                        :key="siteDocumentKey"
-                        graph-slug="heritage_site"
-                        node-alias="document_description"
-                        :should-show-label="true"
-                        :mode="EDIT"
-                        :aliased-node-data="
-                            siteDocument.value?.aliased_data
-                                ?.document_description
-                        "
-                        @update:value="
-                            updateModelValue($event, 'document_description')
-                        "
-                    ></GenericWidget>
-                    <br />
-                </div>
-            </div>
+            <LabelledInput
+                label="Document"
+                input-name="document"
+                :error-message="$form.site_document?.error?.message"
+                :required="true"
+            >
+                <GenericWidget
+                    :required="true"
+                    :key="siteDocumentKey"
+                    graph-slug="heritage_site"
+                    node-alias="site_document"
+                    :should-show-label="false"
+                    :mode="EDIT"
+                    :aliased-node-data="
+                        siteDocument.value?.aliased_data?.site_document
+                    "
+                    @update:value="updateModelValue($event, 'site_document')"
+                ></GenericWidget>
+            </LabelledInput>
+            <LabelledInput
+                label="Document Type"
+                input-name="document"
+                :error-message="$form.document_type?.error?.message"
+                :required="true"
+            >
+                <GenericWidget
+                    :required="true"
+                    :key="siteDocumentKey"
+                    graph-slug="heritage_site"
+                    node-alias="document_type"
+                    :should-show-label="false"
+                    :mode="EDIT"
+                    :card-x-node-x-widget-data-overrides="documentTypeOverrides"
+                    :aliased-node-data="
+                        siteDocument.value?.aliased_data?.document_type
+                    "
+                    @update:value="updateModelValue($event, 'document_type')"
+                ></GenericWidget>
+            </LabelledInput>
+            <LabelledInput
+                label="Document Description"
+                input-name="document"
+                :error-message="$form.document_description?.error?.message"
+                :required="true"
+                hint="Provide a short description of the document content"
+            >
+                <GenericWidget
+                    :required="true"
+                    :key="siteDocumentKey"
+                    graph-slug="heritage_site"
+                    node-alias="document_description"
+                    :should-show-label="false"
+                    :mode="EDIT"
+                    :aliased-node-data="
+                        siteDocument.value?.aliased_data?.document_description
+                    "
+                    @update:value="
+                        updateModelValue($event, 'document_description')
+                    "
+                ></GenericWidget>
+            </LabelledInput>
+            <br />
         </FieldSet>
     </Form>
     <br />

--- a/bcrhp/src/bcrhp/pages/NewSite/steps/Step10_SupportingDocuments.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/steps/Step10_SupportingDocuments.vue
@@ -45,7 +45,7 @@ const supportingDocumentsResolver = getFlattenResolver(
 );
 
 const isValid = () => {
-    return true;
+    return siteDocumentList.value.length > 0;
 };
 
 const documentTypeOverrides = {
@@ -95,10 +95,14 @@ const saveDocument = async function () {
     siteDocument.value = getSiteDocument();
     siteDocumentKey.value++;
     supportingDocumentsForm.value?.reset();
+
+    emit('update:stepIsValid', isValid());
 };
 
 const deleteSiteDocument = function (index: number) {
     heritageSite.value.aliased_data.site_document.splice(index, 1);
+
+    emit('update:stepIsValid', isValid());
 };
 
 defineExpose({ isValid });

--- a/bcrhp/src/bcrhp/pages/NewSite/steps/Step11_ReviewSubmission.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/steps/Step11_ReviewSubmission.vue
@@ -14,6 +14,7 @@ const today = currentDateValue();
 
 defineProps<{
     submissionErrors: ErrorMessage[];
+    submissionComplete?: boolean;
 }>();
 
 // Helper to safely get the addresses
@@ -112,7 +113,7 @@ defineExpose({ isValid });
             </Message>
         </div>
     </section>
-    <p>
+    <p v-if="!submissionComplete">
         Please review the entered information prior to submitting the
         application:
     </p>

--- a/bcrhp/src/bcrhp/pages/NewSite/steps/Step11_ReviewSubmission.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/steps/Step11_ReviewSubmission.vue
@@ -146,39 +146,6 @@ defineExpose({ isValid });
                             .display_value || '-'
                     }}
                 </dd>
-
-                <dt>Legal Description(s)</dt>
-                <dd>
-                    <div
-                        v-for="legalDescription in property_address.aliased_data
-                            .bc_property_legal_description || []"
-                        :key="legalDescription"
-                    >
-                        <div>
-                            <span>PID:</span>
-                            {{
-                                legalDescription.aliased_data.pid
-                                    ?.display_value || 'N/A'
-                            }}
-                        </div>
-                        <div>
-                            <span>Description:</span>
-                            {{
-                                legalDescription.aliased_data.legal_description
-                                    ?.display_value || 'N/A'
-                            }}
-                        </div>
-                    </div>
-
-                    <div
-                        v-if="
-                            !property_address.aliased_data
-                                .bc_property_legal_description?.length
-                        "
-                    >
-                        No legal descriptions recorded.
-                    </div>
-                </dd>
             </div>
         </div>
     </Fieldset>

--- a/bcrhp/src/bcrhp/pages/NewSite/steps/Step4_SiteNames.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/steps/Step4_SiteNames.vue
@@ -130,7 +130,7 @@ const saveOtherName = function () {
 };
 
 const addOtherNameDisabled = computed(
-    () => !isOtherNameValid() || otherNames.value.length >= 4,
+    () => !isOtherNameValid() || otherNames.value.length >= 5,
 );
 
 const deleteOtherNameCallback = function (nameToDelete: any) {

--- a/bcrhp/src/bcrhp/pages/NewSite/steps/Step6_SOS.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/steps/Step6_SOS.vue
@@ -90,6 +90,7 @@ defineExpose({ isValid });
                     hint="Briefly describe the site as it exists today, where it is located (including province) and its physical extent and contributing resources"
                     input-name="physical_description"
                     :error-message="$form.physical_description?.error?.message"
+                    :required="true"
                 >
                     <div class="p-inputtext-fluid">
                         <GenericWidget
@@ -110,6 +111,7 @@ defineExpose({ isValid });
                     hint="Describe why the place is valued by the community and identify which heritage values the official recognition is based on"
                     input-name="heritage_value"
                     :error-message="$form.heritage_value?.error?.message"
+                    :required="true"
                 >
                     <div class="p-inputtext-fluid">
                         <GenericWidget
@@ -130,6 +132,7 @@ defineExpose({ isValid });
                     hint="List the key features of the heritage site that contribute to its heritage value in bullet-point format"
                     input-name="defining_elements"
                     :error-message="$form.defining_elements?.error?.message"
+                    :required="true"
                 >
                     <div class="p-inputtext-fluid">
                         <GenericWidget
@@ -150,6 +153,7 @@ defineExpose({ isValid });
                     hint="Enter the government or agency name where the original document was created."
                     input-name="document_location"
                     :error-message="$form.document_location?.error?.message"
+                    :required="true"
                 >
                     <div class="p-inputtext-fluid">
                         <GenericWidget

--- a/bcrhp/src/bcrhp/pages/NewSite/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/steps/Step8_SiteClassification.vue
@@ -129,9 +129,26 @@ const addHeritageClassDisabled = computed(() => {
     );
 });
 
-const addHeritageFunctionDisabled = computed(
-    () => !isValidHeritageFunction() || heritageFunctions.value.length >= 5,
-);
+const addHeritageFunctionDisabled = computed(() => {
+    const data = currentHeritageFunction.value.aliased_data;
+
+    const hasFunctionCategory = !!(
+        data.functional_category?.display_value ||
+        data.functional_category?.node_value
+    );
+
+    const hasFunctionPeriod = !!(
+        data.functional_state?.display_value ||
+        data.functional_state?.node_value
+    );
+
+    return (
+        !hasFunctionCategory ||
+        !hasFunctionPeriod ||
+        !isValidHeritageFunction() ||
+        heritageFunctions.value.length >= 5
+    );
+});
 
 const getText = (node: any) => {
     if (!node) return '';

--- a/bcrhp/src/bcrhp/pages/NewSite/steps/Step8_SiteClassification.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/steps/Step8_SiteClassification.vue
@@ -108,9 +108,13 @@ const isValid = () => {
 
 const addHeritageClassDisabled = computed(() => {
     const data = currentHeritageClass.value.aliased_data;
-    const hasResourceCount = !!(
+    const hasCategory = !!(
         data.heritage_category?.display_value ||
         data.heritage_category?.node_value
+    );
+    const hasResourceCount = !!(
+        data.contributing_resource_count?.display_value ||
+        data.contributing_resource_count?.node_value
     );
     const hasOwnership = !!(
         data.ownership?.display_value || data.ownership?.node_value
@@ -118,6 +122,7 @@ const addHeritageClassDisabled = computed(() => {
 
     return (
         !hasResourceCount ||
+        !hasCategory ||
         !hasOwnership ||
         !isValidHeritageClass() ||
         heritageClasses.value.length >= 5

--- a/bcrhp/src/bcrhp/pages/NewSite/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/steps/Step9_SiteDetails.vue
@@ -368,38 +368,53 @@ defineExpose({ isValid });
                     </div>
                 </div>
                 <div class="flex flex-row flex-grow">
-                    <GenericWidget
-                        :mode="EDIT"
-                        :should-show-label="true"
-                        :aliasedNodeData="
-                            currentChronology.aliased_data.start_year
+                    <LabelledInput
+                        label="Start Year"
+                        hint="Year the event started"
+                        input-name="ChronologyStartYear"
+                        :error-message="
+                            $form.chronologyStartYear?.error?.message
                         "
-                        graph-slug="heritage_site"
-                        node-alias="start_year"
-                        placeholder="Select a Start Year"
-                        group-direction="column"
-                        class="flex-grow"
-                        @update:value="
-                            updateChronologyModelValue($event, 'start_year')
-                        "
-                    />
-                    <GenericWidget
-                        :mode="EDIT"
-                        :should-show-label="true"
-                        :aliasedNodeData="
-                            currentChronology.aliased_data.end_year
-                        "
-                        graph-slug="heritage_site"
-                        node-alias="end_year"
-                        placeholder="Select an End Year"
-                        group-direction="column"
-                        class="flex-grow"
-                        @update:value="
-                            updateChronologyModelValue($event, 'end_year')
-                        "
-                    />
-
-                    <div class="align-bottom">
+                    >
+                        <GenericWidget
+                            :mode="EDIT"
+                            :should-show-label="false"
+                            :aliasedNodeData="
+                                currentChronology.aliased_data.start_year
+                            "
+                            graph-slug="heritage_site"
+                            node-alias="start_year"
+                            placeholder="Select a Start Year"
+                            group-direction="column"
+                            class="flex-grow"
+                            @update:value="
+                                updateChronologyModelValue($event, 'start_year')
+                            "
+                        />
+                    </LabelledInput>
+                    <LabelledInput
+                        label="End Year"
+                        hint="Year the event ended if applicable"
+                        input-name="ChronologyEndYear"
+                        :error-message="$form.chronologyEndYear?.error?.message"
+                    >
+                        <GenericWidget
+                            :mode="EDIT"
+                            :should-show-label="false"
+                            :aliasedNodeData="
+                                currentChronology.aliased_data.end_year
+                            "
+                            graph-slug="heritage_site"
+                            node-alias="end_year"
+                            placeholder="Select an End Year"
+                            group-direction="column"
+                            class="flex-grow"
+                            @update:value="
+                                updateChronologyModelValue($event, 'end_year')
+                            "
+                        />
+                    </LabelledInput>
+                    <div class="align-checkbox">
                         <div class="flex flex-row flex-row-checkbox">
                             <GenericWidget
                                 :mode="EDIT"
@@ -628,28 +643,37 @@ defineExpose({ isValid });
                         "
                     />
                 </LabelledInput>
-
                 <LabelledInput
-                    hint="e.g. https://www.example.com"
+                    hint="Enter text that describes the link, URL must be stable and publicly accessible "
                     input-name="external_url"
                     class="flex-grow"
                     :error-message="$form.external_url?.error?.message"
                 >
-                    <GenericWidget
-                        class="bold"
-                        :required="true"
-                        :mode="EDIT"
-                        :should-show-label="false"
-                        :aliasedNodeData="
-                            currentExternalUrl.aliased_data.external_url
-                        "
-                        graph-slug="heritage_site"
-                        node-alias="external_url"
-                        group-direction="column"
-                        @update:value="
-                            updateExternalUrlModelValue($event, 'external_url')
-                        "
-                    />
+                    <FieldSet>
+                        <template #legend>
+                            <span class="bold fieldset-subheader">
+                                <span class="red">* </span>URL information
+                            </span>
+                        </template>
+                        <GenericWidget
+                            class="bold"
+                            :required="true"
+                            :mode="EDIT"
+                            :should-show-label="false"
+                            :aliasedNodeData="
+                                currentExternalUrl.aliased_data.external_url
+                            "
+                            graph-slug="heritage_site"
+                            node-alias="external_url"
+                            group-direction="column"
+                            @update:value="
+                                updateExternalUrlModelValue(
+                                    $event,
+                                    'external_url',
+                                )
+                            "
+                        />
+                    </FieldSet>
                 </LabelledInput>
             </div>
         </FieldSet>
@@ -687,9 +711,8 @@ defineExpose({ isValid });
     flex-grow: 1;
 }
 
-.align-bottom {
-    margin-bottom: 0;
-    margin-top: auto;
+.align-checkbox {
+    align-self: center;
 }
 
 .button-padding {
@@ -704,5 +727,8 @@ defineExpose({ isValid });
 }
 .bold {
     font-weight: bold;
+}
+.fieldset-subheader {
+    font-size: 1rem;
 }
 </style>

--- a/bcrhp/src/bcrhp/pages/NewSite/steps/Step9_SiteDetails.vue
+++ b/bcrhp/src/bcrhp/pages/NewSite/steps/Step9_SiteDetails.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { useTemplateRef, inject, ref, computed } from 'vue';
 import type { Ref } from 'vue';
-// [ADDED] Import z from zod to define local schema
 import { z } from 'zod';
 
 import FieldSet from 'primevue/fieldset';
@@ -152,10 +151,7 @@ const isValidConstructionActors = () =>
 const addConstructionActorDisabled = computed(() => {
     const data = currentConstructionActor.value.aliased_data;
 
-    const hasName = !!(
-        data.construction_actor?.display_value ||
-        data.construction_actor?.node_value
-    );
+    const hasName = getText(data.construction_actor).trim().length > 0;
 
     const hasType = !!(
         data.construction_actor_type?.display_value ||


### PR DESCRIPTION
Added disclaimer for steps 6-10 closes #129
Fields on step 6 are now required closes #126
Next button on step 10 is now disabled until a document is uploaded closes #128
All three fields of heritage class are now needed to add a heritage class on step 8 closes #135
Updated functionality of heritage function fields on step 8 closes #136
Updated architects / builders validation on step 9 closes #137
Increased the amount of other names allowed to 5 closes #138
Removed legal descriptions from review page closes #141
Added in missing hints on start and end year on step 9 closes #144
The default URL widget contains two fields and does not allow hints to be placed between input fields so I've combined the hints and created a subsection to clarify. Please review issues #145 and #146.