### PR TITLE
Add plugin permission for local government group to view plugin

### DIFF
--- a/bcrhp/migrations/0065_add_plugin_config.py
+++ b/bcrhp/migrations/0065_add_plugin_config.py
@@ -28,7 +28,14 @@ def remote_plugin_config(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("bcrhp", "0003_post_package_load"),
+        (
+            "bcrhp",
+            "0003_post_package_load",
+        ),
+        (
+            "guardian",
+            "0002_generic_permissions_index",
+        ),
     ]
 
     operations = [migrations.RunPython(add_plugin_config, remote_plugin_config)]

--- a/bcrhp/migrations/0065_add_plugin_config.py
+++ b/bcrhp/migrations/0065_add_plugin_config.py
@@ -16,7 +16,7 @@ def add_plugin_config(apps, schema_editor):
     plugin.sortorder = 0
     plugin.save()
 
-    group = Group.objects.get(name="Local Government")
+    group = Group.objects.get_or_create(name="Local Government")[0]
     assign_perm("view_plugin", group, plugin)
 
 

--- a/bcrhp/migrations/0065_add_plugin_config.py
+++ b/bcrhp/migrations/0065_add_plugin_config.py
@@ -1,4 +1,6 @@
 from arches.app.models.models import Plugin
+from django.contrib.auth.models import Group
+from guardian.shortcuts import assign_perm
 
 from django.db import migrations
 
@@ -13,6 +15,9 @@ def add_plugin_config(apps, schema_editor):
     plugin.config = {"show": True, "workflows": []}
     plugin.sortorder = 0
     plugin.save()
+
+    group = Group.objects.get(name="Local Government")
+    assign_perm("view_plugin", group, plugin)
 
 
 def remote_plugin_config(apps, schema_editor):


### PR DESCRIPTION
closes #193

This fix adds the permission to an already existing migration. If this has been applied already perform the following:

```
python manage.py migrate bcrhp 0003_post_package_load
python manage.py migrate bcrhp 
```