### PR TITLE
Apply guardian permissions 

### DIFF
--- a/bcrhp/migrations/0206_guest_no_access_admin_nodegroups.py
+++ b/bcrhp/migrations/0206_guest_no_access_admin_nodegroups.py
@@ -6,7 +6,7 @@ from guardian.shortcuts import assign_perm, remove_perm
 
 from arches.app.models.models import Node
 
-lg_pairs = [
+lg_nodes = [
     ("heritage_site", "internal_remark"),
     ("heritage_site", "site_record_admin"),
     ("heritage_site_historical_data", "decision_history_n1"),
@@ -18,7 +18,7 @@ lg_pairs = [
     ("project_sandbox", "sandcastle_project"),
 ]
 
-guest_pairs = [
+guest_nodes = [
     ("heritage_site", "internal_remark"),
     ("heritage_site", "site_record_admin"),
 ]
@@ -36,7 +36,7 @@ def get_nodegroups(pairs):
 def guest_forwards(apps, schema_editor):
     groups = Group.objects.filter(name="Guest").all()
 
-    for nodegroup in get_nodegroups(guest_pairs):
+    for nodegroup in get_nodegroups(guest_nodes):
         for group in groups:
             assign_perm("no_access_to_nodegroup", group, nodegroup)
     user_permission_cache = caches["user_permission"]
@@ -46,7 +46,7 @@ def guest_forwards(apps, schema_editor):
 
 def guest_backwards(apps, schema_editor):
     groups = Group.objects.filter(name="Guest").all()
-    nodegroups = get_nodegroups(guest_pairs)
+    nodegroups = get_nodegroups(guest_nodes)
     for nodegroup in nodegroups:
         for group in groups:
             remove_perm("no_access_to_nodegroup", group, nodegroup)
@@ -58,7 +58,7 @@ def guest_backwards(apps, schema_editor):
 def lg_forwards(apps, schema_editor):
     groups = Group.objects.filter(name="Local Government").all()
 
-    for nodegroup in get_nodegroups(lg_pairs):
+    for nodegroup in get_nodegroups(lg_nodes):
         for group in groups:
             assign_perm("no_access_to_nodegroup", group, nodegroup)
     user_permission_cache = caches["user_permission"]
@@ -68,7 +68,7 @@ def lg_forwards(apps, schema_editor):
 
 def lg_backwards(apps, schema_editor):
     groups = Group.objects.filter(name="Local Government").all()
-    nodegroups = get_nodegroups(lg_pairs)
+    nodegroups = get_nodegroups(lg_nodes)
     for nodegroup in nodegroups:
         for group in groups:
             remove_perm("no_access_to_nodegroup", group, nodegroup)

--- a/bcrhp/migrations/0206_guest_no_access_admin_nodegroups.py
+++ b/bcrhp/migrations/0206_guest_no_access_admin_nodegroups.py
@@ -82,6 +82,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ("bcrhp", "0186_remove_permission_functions"),
         ("guardian", "0002_generic_permissions_index"),
+        ("models", "12343_generate_geom_feature_id"),
     ]
 
     operations = [

--- a/bcrhp/migrations/0206_guest_no_access_admin_nodegroups.py
+++ b/bcrhp/migrations/0206_guest_no_access_admin_nodegroups.py
@@ -1,0 +1,46 @@
+from django.contrib.auth.models import Group, User
+from django.core.cache import caches
+from django.db import migrations
+from guardian.shortcuts import assign_perm, remove_perm
+
+from arches.app.models.models import Node
+
+groups_to_change = ["Guest", "Local Government"]
+
+
+def forwards(apps, schema_editor):
+    groups = Group.objects.filter(name__in=groups_to_change).all()
+    nodegroups = [
+        Node.objects.get(alias="internal_remark").nodegroup,
+        Node.objects.get(alias="site_record_admin").nodegroup,
+    ]
+    for nodegroup in nodegroups:
+        for group in groups:
+            assign_perm("no_access_to_nodegroup", group, nodegroup)
+    user_permission_cache = caches["user_permission"]
+    if user_permission_cache:
+        user_permission_cache.clear()
+
+
+def backwards(apps, schema_editor):
+    groups = Group.objects.filter(name__in=groups_to_change).all()
+    nodegroups = [
+        Node.objects.get(alias="internal_remark").nodegroup,
+        Node.objects.get(alias="site_record_admin").nodegroup,
+    ]
+    for nodegroup in nodegroups:
+        for group in groups:
+            remove_perm("no_access_to_nodegroup", group, nodegroup)
+    user_permission_cache = caches["user_permission"]
+    if user_permission_cache:
+        user_permission_cache.clear()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bcrhp", "0186_remove_permission_functions"),
+        ("guardian", "0002_generic_permissions_index"),
+    ]
+
+    operations = [migrations.RunPython(forwards, backwards)]

--- a/bcrhp/migrations/0206_guest_no_access_admin_nodegroups.py
+++ b/bcrhp/migrations/0206_guest_no_access_admin_nodegroups.py
@@ -1,20 +1,42 @@
 from django.contrib.auth.models import Group, User
 from django.core.cache import caches
 from django.db import migrations
+from django.db.models import Q
 from guardian.shortcuts import assign_perm, remove_perm
 
 from arches.app.models.models import Node
 
-groups_to_change = ["Guest", "Local Government"]
+lg_pairs = [
+    ("heritage_site", "internal_remark"),
+    ("heritage_site", "site_record_admin"),
+    ("heritage_site_historical_data", "decision_history_n1"),
+    ("lg_person", "contact_information"),
+    ("lg_person", "government_association"),
+    ("lg_person", "government_person_name"),
+    ("lg_person", "username"),
+    ("project_sandbox", "project_boundary"),
+    ("project_sandbox", "sandcastle_project"),
+]
+
+guest_pairs = [
+    ("heritage_site", "internal_remark"),
+    ("heritage_site", "site_record_admin"),
+]
 
 
-def forwards(apps, schema_editor):
-    groups = Group.objects.filter(name__in=groups_to_change).all()
-    nodegroups = [
-        Node.objects.get(alias="internal_remark").nodegroup,
-        Node.objects.get(alias="site_record_admin").nodegroup,
-    ]
-    for nodegroup in nodegroups:
+def get_nodegroups(pairs):
+    query = Q()
+    for slug, alias in pairs:
+        query |= Q(graph__slug=slug, alias=alias)
+
+    nodes = list(Node.objects.filter(query).select_related("graph"))
+    return [node.nodegroup for node in nodes]
+
+
+def guest_forwards(apps, schema_editor):
+    groups = Group.objects.filter(name="Guest").all()
+
+    for nodegroup in get_nodegroups(guest_pairs):
         for group in groups:
             assign_perm("no_access_to_nodegroup", group, nodegroup)
     user_permission_cache = caches["user_permission"]
@@ -22,12 +44,31 @@ def forwards(apps, schema_editor):
         user_permission_cache.clear()
 
 
-def backwards(apps, schema_editor):
-    groups = Group.objects.filter(name__in=groups_to_change).all()
-    nodegroups = [
-        Node.objects.get(alias="internal_remark").nodegroup,
-        Node.objects.get(alias="site_record_admin").nodegroup,
-    ]
+def guest_backwards(apps, schema_editor):
+    groups = Group.objects.filter(name="Guest").all()
+    nodegroups = get_nodegroups(guest_pairs)
+    for nodegroup in nodegroups:
+        for group in groups:
+            remove_perm("no_access_to_nodegroup", group, nodegroup)
+    user_permission_cache = caches["user_permission"]
+    if user_permission_cache:
+        user_permission_cache.clear()
+
+
+def lg_forwards(apps, schema_editor):
+    groups = Group.objects.filter(name="Local Government").all()
+
+    for nodegroup in get_nodegroups(lg_pairs):
+        for group in groups:
+            assign_perm("no_access_to_nodegroup", group, nodegroup)
+    user_permission_cache = caches["user_permission"]
+    if user_permission_cache:
+        user_permission_cache.clear()
+
+
+def lg_backwards(apps, schema_editor):
+    groups = Group.objects.filter(name="Local Government").all()
+    nodegroups = get_nodegroups(lg_pairs)
     for nodegroup in nodegroups:
         for group in groups:
             remove_perm("no_access_to_nodegroup", group, nodegroup)
@@ -43,4 +84,7 @@ class Migration(migrations.Migration):
         ("guardian", "0002_generic_permissions_index"),
     ]
 
-    operations = [migrations.RunPython(forwards, backwards)]
+    operations = [
+        migrations.RunPython(guest_forwards, guest_backwards),
+        migrations.RunPython(lg_forwards, lg_backwards),
+    ]


### PR DESCRIPTION
- to hide internal remark and admin info from Guest group
- also applied the same restrctions to Local Government group (along with the base set of non-Heritage Site restrictions
